### PR TITLE
Added new functions

### DIFF
--- a/variables.php
+++ b/variables.php
@@ -79,6 +79,9 @@ function normcdf($x, $mu, $sigma) {
 function modpow($a, $b, $m) {
     $bin = decbin($b);
     $res = $a;
+    if ($b == 0) {
+        return 1;
+    }
     for ($i=1; $i<strlen($bin); $i++) {
         if ($bin[$i] == "0") {
             $res = ($res*$res) % $m;


### PR DESCRIPTION
This PR adds the following new functions to the plugin:

### Statistics

 - `stdnormpdf($z)`: standard normal distribution's density function
 - `stdnormcdf($z)`: standard normal distribution's cumulative distribution function
 - `normcdf($x, $mu, $sigma)` normal distribution's cumulative distribution function for mean = `$mu` and standard deviation = `$sigma`

The CDF values are approxmations (~ 5 decimal places), calculated using Simpson's rule. The PDF is exact (within the limits of the computer's accuracy, of course) despite the commit message saying it is only an approximation. 

### Number theory 

 - `modpow($a, $b, $m)` raises `$a` to the `$b`-th power modulo `$m` using the efficient square-and-multiply algorithm
 - `modinv($a, $m)` yields the multiplicative inverse of `$a` modulo `$m` or 0 if the inverse does not exist using the extended euclidean algorithm as described on e.g. Wikipedia