### PR TITLE
Phpunit test fix failures and risk

### DIFF
--- a/tests/helper.php
+++ b/tests/helper.php
@@ -487,6 +487,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $form->varsrandom = '';
         $form->varsglobal = 'v = 40;dt = 3;s = v*dt;';
         $form->answernumbering = 'abc';
+        $form->noanswers = 4;
         $form->answer = array(
             0 => 'v',
             1 => 'v',

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -202,6 +202,11 @@ class qtype_formulas_test extends advanced_testcase {
         // Now we are going to delete the options record.
         $DB->delete_records('qtype_formulas_options', ['questionid' => $question->id]);
 
+        // Notifications we expect due to missing options
+        $this->expectOutputString('!! Failed to load question options from the table qtype_formulas_options for questionid ' . $question->id . ' !!
+!! Failed to load question options from the table qtype_formulas_options for questionid ' . $question->id . ' !!
+');
+
         // Now see what happens.
         $question = $DB->get_record('question', ['id' => $returnedfromsave->id], '*', MUST_EXIST);
         $this->qtype->get_question_options($question);


### PR DESCRIPTION
Fix for successful phpunit test.
Allows to pass checks assertCount(4, $options->answers).
And removes Risky of notice output.