### PR TITLE
Fix pick() function

### DIFF
--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -52,11 +52,11 @@ class qtype_formulas_test extends advanced_testcase {
         return test_question_maker::make_question('formulas', $which);
     }
 
-    protected function setUp() {
+    protected function setUp():void {
         $this->qtype = new qtype_formulas();
     }
 
-    protected function tearDown() {
+    protected function tearDown():void {
         $this->qtype = null;
     }
 

--- a/tests/variables_test.php
+++ b/tests/variables_test.php
@@ -196,20 +196,100 @@ class qtype_formulas_variables_test extends advanced_testcase {
                     'c' => (object) array('type' => 'ls', 'value' => array('rr', 'rr', 'rr', 'rr')),
                     )
             ),
-            array(true, 'p1=pick(4,[2,3,5,7,11]);', array(
-                    'p1' => (object) array('type' => 'n', 'value' => 2),
+            array(true, 'p1=pick(3,[0,1,2,3,4,5]);', array(
+                    'p1' => (object) array('type' => 'n', 'value' => 3),
                     )
             ),
-            array(true, 'p1=pick(3.1,[2,3,5,7,11]);', array(
-                    'p1' => (object) array('type' => 'n', 'value' => 2),
+            array(true, 'p1=pick(3.9,[0,1,2,3,4,5]);', array(
+                    'p1' => (object) array('type' => 'n', 'value' => 3),
                     )
             ),
-            array(true, 'p1=pick(1000,[2,3,5,7,11]);', array(
-                    'p1' => (object) array('type' => 'n', 'value' => 2),
+            array(true, 'p1=pick(10,[0,1,2,3,4,5]);', array(
+                    'p1' => (object) array('type' => 'n', 'value' => 0),
                     )
             ),
-            array(true, 'p1=pick(2,[2,3],[4,5],[6,7]);', array(
-                    'p1' => (object) array('type' => 'ln', 'value' => array(6, 7)),
+            array(true, 'p1=pick(10.9,[0,1,2,3,4,5]);', array(
+                    'p1' => (object) array('type' => 'n', 'value' => 0),
+                    )
+            ),
+            array(true, 'p1=pick(3,0,1,2,3,4,5);', array(
+                    'p1' => (object) array('type' => 'n', 'value' => 3),
+                    )
+            ),
+            array(true, 'p1=pick(3.9,0,1,2,3,4,5);', array(
+                    'p1' => (object) array('type' => 'n', 'value' => 3),
+                    )
+            ),
+            array(true, 'p1=pick(10,0,1,2,3,4,5);', array(
+                    'p1' => (object) array('type' => 'n', 'value' => 0),
+                    )
+            ),
+            array(true, 'p1=pick(10.9,0,1,2,3,4,5);', array(
+                    'p1' => (object) array('type' => 'n', 'value' => 0),
+                    )
+            ),
+            array(true, 'p1=pick(3,["A","B","C","D","E","F"]);', array(
+                    'p1' => (object) array('type' => 's', 'value' => "D"),
+                    )
+            ),
+            array(true, 'p1=pick(3.9,["A","B","C","D","E","F"]);', array(
+                    'p1' => (object) array('type' => 's', 'value' => "D"),
+                    )
+            ),
+            array(true, 'p1=pick(10,["A","B","C","D","E","F"]);', array(
+                    'p1' => (object) array('type' => 's', 'value' => "A"),
+                    )
+            ),
+            array(true, 'p1=pick(10.9,["A","B","C","D","E","F"]);', array(
+                    'p1' => (object) array('type' => 's', 'value' => "A"),
+                    )
+            ),
+            array(true, 'p1=pick(3,"A","B","C","D","E","F");', array(
+                    'p1' => (object) array('type' => 's', 'value' => "D"),
+                    )
+            ),
+            array(true, 'p1=pick(3.9,"A","B","C","D","E","F");', array(
+                    'p1' => (object) array('type' => 's', 'value' => "D"),
+                    )
+            ),
+            array(true, 'p1=pick(10,"A","B","C","D","E","F");', array(
+                    'p1' => (object) array('type' => 's', 'value' => "A"),
+                    )
+            ),
+            array(true, 'p1=pick(10.9,"A","B","C","D","E","F");', array(
+                    'p1' => (object) array('type' => 's', 'value' => "A"),
+                    )
+            ),
+            array(true, 'p1=pick(3,[0,0],[1,1],[2,2],[3,3],[4,4],[5,5]);', array(
+                'p1' => (object) array('type' => 'ln', 'value' => array(3, 3)),
+                    )
+            ),
+            array(true, 'p1=pick(3.9,[0,0],[1,1],[2,2],[3,3],[4,4],[5,5]);', array(
+                'p1' => (object) array('type' => 'ln', 'value' => array(3, 3)),
+                    )
+            ),
+            array(true, 'p1=pick(10,[0,0],[1,1],[2,2],[3,3],[4,4],[5,5]);', array(
+                'p1' => (object) array('type' => 'ln', 'value' => array(0, 0)),
+                    )
+            ),
+            array(true, 'p1=pick(10.9,[0,0],[1,1],[2,2],[3,3],[4,4],[5,5]);', array(
+                'p1' => (object) array('type' => 'ln', 'value' => array(0, 0)),
+                    )
+            ),
+            array(true, 'p1=pick(3,["A","A"],["B","B"],["C","C"],["D","D"],["E","E"],["F","F"]);', array(
+                'p1' => (object) array('type' => 'ls', 'value' => array("D", "D")),
+                    )
+            ),
+            array(true, 'p1=pick(3.9,["A","A"],["B","B"],["C","C"],["D","D"],["E","E"],["F","F"]);', array(
+                'p1' => (object) array('type' => 'ls', 'value' => array("D", "D")),
+                    )
+            ),
+            array(true, 'p1=pick(10,["A","A"],["B","B"],["C","C"],["D","D"],["E","E"],["F","F"]);', array(
+                'p1' => (object) array('type' => 'ls', 'value' => array("A", "A")),
+                    )
+            ),
+            array(true, 'p1=pick(10.9,["A","A"],["B","B"],["C","C"],["D","D"],["E","E"],["F","F"]);', array(
+                'p1' => (object) array('type' => 'ls', 'value' => array("A", "A")),
                     )
             ),
             array(true, 's=sort([7,5,3,11,2]);', array(

--- a/variables.php
+++ b/variables.php
@@ -816,7 +816,7 @@ class qtype_formulas_variables {
                     }
                     if (!$allsametype)  break;
                 }
-                $v = intval($values[0] >= 0 && $values[0] < count($pool) ? $values[0] : 0);    // Always choose 0 if index out of range.
+                $v = intval($values[0] >= 0 && $values[0] < mycount($pool) ? $values[0] : 0);    // Always choose 0 if index out of range.
                 $this->replace_middle($vstack, $expression, $l, $r, $type, $pool[$v]);
                 return true;
             case 'sort':

--- a/variables.php
+++ b/variables.php
@@ -816,7 +816,7 @@ class qtype_formulas_variables {
                     }
                     if (!$allsametype)  break;
                 }
-                $v = intval($values[0] >= 0 && $values[0] < $sz ? $values[0] : 0);    // Always choose 0 if index out of range.
+                $v = intval($values[0] >= 0 && $values[0] < count($pool) ? $values[0] : 0);    // Always choose 0 if index out of range.
                 $this->replace_middle($vstack, $expression, $l, $r, $type, $pool[$v]);
                 return true;
             case 'sort':


### PR DESCRIPTION
The error described in issue #28 comes from the fact that the given index is reset, because instead of comparing it to the number of items to pick from, it is compared to the number of arguments. However, when the second argument is a list, that count is only 2 and thus we cannot pick elements further down the list.

This PR fixes #28.