### PR TITLE
test invocation for all documented functions

### DIFF
--- a/tests/functions_test.php
+++ b/tests/functions_test.php
@@ -530,4 +530,312 @@ class functions_test extends \advanced_testcase {
             $this->assertEqualsWithDelta($case[1], $case[0], .00001);
         }
     }
+
+    /**
+    * Test: incovation of all documented trigonometric / hyberbolic functions
+    */
+    public function test_invocation_trigonometric() {
+        $testcases = array(
+            array(true, 'a=acos(0.5);'),
+            array(false, 'a=acos();'),
+            array(false, 'a=acos(1, 2);'),
+            array(true, 'a=asin(0.5);'),
+            array(false, 'a=asin();'),
+            array(false, 'a=asin(1, 2);'),
+            array(true, 'a=atan(0.5);'),
+            array(false, 'a=atan();'),
+            array(false, 'a=atan(1, 2);'),
+            array(true, 'a=atan2(1, 2);'),
+            array(false, 'a=atan2(1, 2, 3);'),
+            array(false, 'a=atan2(1);'),
+            array(false, 'a=atan2();'),
+            array(true, 'a=cos(0.5);'),
+            array(false, 'a=cos();'),
+            array(false, 'a=cos(1, 2);'),
+            array(true, 'a=sin(0.5);'),
+            array(false, 'a=sin();'),
+            array(false, 'a=sin(1, 2);'),
+            array(true, 'a=tan(0.5);'),
+            array(false, 'a=tan();'),
+            array(false, 'a=tan(1, 2);'),
+            array(true, 'a=acosh(0.5);'),
+            array(false, 'a=acosh();'),
+            array(false, 'a=acosh(1, 2);'),
+            array(true, 'a=asinh(0.5);'),
+            array(false, 'a=asinh();'),
+            array(false, 'a=asinh(1, 2);'),
+            array(true, 'a=atanh(0.5);'),
+            array(false, 'a=atanh();'),
+            array(false, 'a=atanh(1, 2);'),
+            array(true, 'a=cosh(0.5);'),
+            array(false, 'a=cosh();'),
+            array(false, 'a=cosh(1, 2);'),
+            array(true, 'a=sinh(0.5);'),
+            array(false, 'a=sinh();'),
+            array(false, 'a=sinh(1, 2);'),
+            array(true, 'a=tanh(0.5);'),
+            array(false, 'a=tanh();'),
+            array(false, 'a=tanh(1, 2);'),
+        );
+        $qv = new variables;
+        foreach ($testcases as $case) {
+            $errmsg = null;
+            try {
+                $v = $qv->vstack_create();
+                $qv->evaluate_assignments($v, $case[1]);
+            } catch (Exception $e) {
+                $errmsg = $e->getMessage();
+            }
+            if ($case[0]) {
+                $this->assertNull($errmsg);
+            } else {
+                $this->assertNotNull($errmsg);
+            }
+        }
+    }
+
+    /**
+    * Test: incovation of all documented combinatorial functions
+    */
+    public function test_invocation_combinatorial() {
+        $testcases = array(
+            array(true, 'a=inv([0, 1, 2, 3]);'),
+            array(false, 'a=inv();'),
+            array(false, 'a=inv(1);'),
+            array(false, 'a=inv(1, 2);'),
+            array(false, 'a=inv([1, 4, 0]);'), // Not consecutive.
+            array(false, 'a=inv([1, 2, 3]);'), // Lowest is not zero.
+            array(false, 'a=inv([1, 2], 1);'),
+            array(false, 'a=inv([1, 2], [3, 4]);'),
+            array(true, 'a=ncr(5, 2);'),
+            array(false, 'a=ncr();'),
+            array(false, 'a=ncr(2);'),
+            array(false, 'a=ncr(5, 2, 3);'),
+            array(true, 'a=npr(5, 2);'),
+            array(false, 'a=npr();'),
+            array(false, 'a=npr(2);'),
+            array(false, 'a=npr(5, 2, 3);'),
+        );
+        $qv = new variables;
+        foreach ($testcases as $case) {
+            $errmsg = null;
+            try {
+                $v = $qv->vstack_create();
+                $qv->evaluate_assignments($v, $case[1]);
+            } catch (Exception $e) {
+                $errmsg = $e->getMessage();
+            }
+            if ($case[0]) {
+                $this->assertNull($errmsg);
+            } else {
+                $this->assertNotNull($errmsg);
+            }
+        }
+    }
+
+    /**
+    * Test: incovation of all documented algebraic / other numerical functions
+    */
+    public function test_invocation_algebraic() {
+        $testcases = array(
+            array(true, 'a=abs(-3);'),
+            array(false, 'a=abs();'),
+            array(false, 'a=abs(1, 2);'),
+            array(true, 'a=ceil(0.5);'),
+            array(false, 'a=ceil();'),
+            array(false, 'a=ceil(1, 2);'),
+            array(true, 'a=deg2rad(0.5);'),
+            array(false, 'a=deg2rad();'),
+            array(false, 'a=deg2rad(1, 2);'),
+            array(true, 'a=exp(0.5);'),
+            array(false, 'a=exp();'),
+            array(false, 'a=exp(1, 2);'),
+            array(true, 'a=expm1(0.5);'),
+            array(false, 'a=expm1();'),
+            array(false, 'a=expm1(1, 2);'),
+            array(true, 'a=fact(3);'),
+            array(false, 'a=fact();'),
+            array(false, 'a=fact(1, 2);'),
+            array(true, 'a=floor(0.5);'),
+            array(false, 'a=floor();'),
+            array(false, 'a=floor(1, 2);'),
+            array(true, 'a=fmod(3, 2);'),
+            array(false, 'a=fmod();'),
+            array(false, 'a=fmod(0.5);'),
+            array(false, 'a=fmod(1, 2, 3);'),
+            array(true, 'a=gcd(3, 2);'),
+            array(false, 'a=gcd();'),
+            array(false, 'a=gcd(0.5);'),
+            array(false, 'a=gcd(1, 2, 3);'),
+            array(true, 'a=is_finite(0.5);'),
+            array(false, 'a=is_finite();'),
+            array(false, 'a=is_finite(1, 2);'),
+            array(true, 'a=is_infinite(0.5);'),
+            array(false, 'a=is_infinite();'),
+            array(false, 'a=is_infinite(1, 2);'),
+            array(true, 'a=is_nan(0.5);'),
+            array(false, 'a=is_nan();'),
+            array(false, 'a=is_nan(1, 2);'),
+            array(true, 'a=lcm(3, 2);'),
+            array(false, 'a=lcm();'),
+            array(false, 'a=lcm(0.5);'),
+            array(false, 'a=lcm(1, 2, 3);'),
+            array(true, 'a=log(0.5, 2);'),
+            array(true, 'a=log(0.5);'),
+            array(false, 'a=log();'),
+            array(false, 'a=log(0.5, 2, 3);'),
+            array(true, 'a=log10(0.5);'),
+            array(false, 'a=log10();'),
+            array(false, 'a=log10(1, 2);'),
+            array(true, 'a=log1p(0.5);'),
+            array(false, 'a=log1p();'),
+            array(false, 'a=log1p(1, 2);'),
+            array(true, 'a=max(1, 2);'),
+            array(true, 'a=max(1, 2, 3);'),
+            array(true, 'a=max(1, 2, 3, 4);'),
+            array(true, 'a=max(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);'),
+            array(false, 'a=max();'),
+            array(false, 'a=max(1);'),
+            array(true, 'a=min(1, 2);'),
+            array(true, 'a=min(1, 2, 3);'),
+            array(true, 'a=min(1, 2, 3, 4);'),
+            array(true, 'a=min(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);'),
+            array(false, 'a=min();'),
+            array(false, 'a=min(1);'),
+            array(true, 'a=modpow(1, 2, 3);'),
+            array(false, 'a=modpow();'),
+            array(false, 'a=modpow(1);'),
+            array(false, 'a=modpow(1, 2);'),
+            array(false, 'a=modpow(1, 2, 3, 4);'),
+            array(true, 'a=pi();'),
+            array(false, 'a=pi(1);'),
+            array(true, 'a=poly("x", [1]);'),
+            array(true, 'a=poly("x", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);'),
+            array(false, 'a=poly("x", 1);'),
+            array(false, 'a=poly("x", 1, 2);'),
+            array(false, 'a=poly("x");'),
+            array(false, 'a=poly();'),
+            array(true, 'a=pow(1, 2);'),
+            array(false, 'a=pow();'),
+            array(false, 'a=pow(1);'),
+            array(false, 'a=pow(1, 2, 3);'),
+            array(true, 'a=rad2deg(0.5);'),
+            array(false, 'a=rad2deg();'),
+            array(false, 'a=rad2deg(1, 2);'),
+            array(true, 'a=round(0.123, 2);'),
+            array(true, 'a=round(0.123);'),
+            array(false, 'a=round();'),
+            array(false, 'a=round(0.123, 2, 3);'),
+            array(true, 'a=sigfig(0.5, 1);'),
+            array(false, 'a=sigfig();'),
+            array(false, 'a=sigfig(1);'),
+            array(false, 'a=sigfig(1, 2, 3);'),
+            array(true, 'a=sqrt(0.5);'),
+            array(false, 'a=sqrt();'),
+            array(false, 'a=sqrt(1, 2);'),
+            array(false, 'a=sqrt(1, 2);'),
+        );
+        $qv = new variables;
+        foreach ($testcases as $case) {
+            $errmsg = null;
+            try {
+                $v = $qv->vstack_create();
+                $qv->evaluate_assignments($v, $case[1]);
+            } catch (Exception $e) {
+                $errmsg = $e->getMessage();
+            }
+            if ($case[0]) {
+                $this->assertNull($errmsg);
+            } else {
+                $this->assertNotNull($errmsg);
+            }
+        }
+    }
+
+    /**
+    * Test: incovation of all documented string/array functions
+    */
+    public function test_invocation_string_array() {
+        $testcases = array(
+            array(true, 'a=concat([1, 2], [2, 4]);'),
+            array(true, 'a=concat([1, 2], [2, 4], [3, 5], [5, 6]);'),
+            array(true, 'a=concat([1], [2], [3], [4], [5], [6]);'),
+            array(true, 'a=concat(["1"], ["2"], ["3"], ["4"], ["5"], ["6"]);'),
+            array(false, 'a=concat();'),
+            array(false, 'a=concat([1, 2]);'),
+            array(false, 'a=concat(1);'),
+            array(false, 'a=concat(1, 2);'),
+            array(true, 'a=diff([1, 2], [2, 4]);'),
+            array(false, 'a=diff();'),
+            array(false, 'a=diff([1, 2]);'),
+            array(false, 'a=diff([1, 2], [2, 4], [3, 5]);'),
+            array(false, 'a=diff(1);'),
+            array(false, 'a=diff(1, 2);'),
+            array(true, 'a=fill(3, "x");'),
+            array(true, 'a=fill(3, 0);'),
+            array(false, 'a=fill(0);'),
+            array(false, 'a=fill(3, 3, 3);'),
+            array(true, 'a=join(" ", ["a", "b"]);'),
+            array(true, 'a=join(" ", ["a", 1]);'),
+            array(true, 'a=join(" ", "a", "b", "c");'),
+            array(true, 'a=join(" ", 1, 2, 3, 4);'),
+            array(false, 'a=join();'),
+            array(false, 'a=join(3);'),
+            array(false, 'a=join(["a", "b"]);'),
+            array(true, 'a=len([1, 2, 3]);'),
+            array(true, 'a=len(["1", "2", "3"]);'),
+            array(true, 'a=len(["1", 2, "3"]);'),
+            array(false, 'a=len();'),
+            array(false, 'a=len(1);'),
+            array(true, 'a=map("+", [1, 2], [3, 4]);'),
+            array(true, 'a=map("abs", [-1, -2]);'),
+            array(false, 'a=map("+", [1, 2]);'), // Binary operator needs two lists.
+            array(false, 'a=map("abs", [-1, -2], [3, 4]);'),
+            array(false, 'a=map("x", [-1, -2]);'),
+            array(false, 'a=map();'),
+            array(false, 'a=map("+");'),
+            array(false, 'a=map("abs");'),
+            array(false, 'a=map([1, 2, 3]);'),
+            array(true, 'a=sort([1, 2, 3]);'),
+            array(true, 'a=sort(["1", "2", "3"]);'),
+            array(true, 'a=sort(["1", 2, "3"]);'),
+            array(false, 'a=sort();'),
+            array(false, 'a=sort(1);'),
+            array(false, 'a=sort(1, 2);'),
+            array(true, 'a=str(1);'),
+            array(false, 'a=str();'),
+            array(false, 'a=str("1");'),
+            array(false, 'a=str(1, 2);'),
+            array(false, 'a=str([1, 2]);'),
+            array(true, 'a=sublist([1, 2, 3], [1, 1, 1, 1]);'),
+            array(false, 'a=sublist();'),
+            array(false, 'a=sublist(1);'),
+            array(false, 'a=sublist(1, 2);'),
+            array(false, 'a=sublist(1, 2, 3);'),
+            array(false, 'a=sublist([1, 2, 3]);'),
+            array(false, 'a=sublist([1, 2, 3], [5]);'), // Index is out of range.
+            array(false, 'a=sublist([1, 2, 3], [1, 1, 1, 1], [1, 2, 3]);'),
+            array(true, 'a=sum([1, 2, 3]);'),
+            array(false, 'a=sum(["1", "2", "3"]);'),
+            array(false, 'a=sum();'),
+            array(false, 'a=sum(1);'),
+            array(false, 'a=sum(1, 2);'),
+            array(false, 'a=sum([1, 2, 3], [1, 2, 3]);'),
+        );
+        $qv = new variables;
+        foreach ($testcases as $case) {
+            $errmsg = null;
+            try {
+                $v = $qv->vstack_create();
+                $qv->evaluate_assignments($v, $case[1]);
+            } catch (Exception $e) {
+                $errmsg = $e->getMessage();
+            }
+            if ($case[0]) {
+                $this->assertNull($errmsg);
+            } else {
+                $this->assertNotNull($errmsg);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Preparation of 5.0.0 introduced a bug that prevented several functions from working properly. This PR makes sure that each function is invoked several times (at least: correct invocation, invocation with fewer arguments than necessary, invocation with at least one more argument than needed) in order to avoid such an error in the future.

As documented in #41, specific unit tests to check the implementation of all "own" functions (functions implemented in `variables.php` vs. functions available from PHP) will follow in a separate PR.

Note: PHP mess detector check is only indicative.