### PR TITLE
offer way to retrieve version number

### DIFF
--- a/tests/functions_test.php
+++ b/tests/functions_test.php
@@ -32,7 +32,6 @@ global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/question/type/formulas/variables.php');
 
-
 /**
  * Unit tests for various functions
  *
@@ -41,6 +40,7 @@ require_once($CFG->dirroot . '/question/type/formulas/variables.php');
  */
 
 class functions_test extends \advanced_testcase {
+
     /**
      * Test 1: ncr() test.
      */
@@ -1028,4 +1028,22 @@ class functions_test extends \advanced_testcase {
             $this->assertStringStartsWith($case[1], $errmsg);
         }
     }
+
+    /**
+     * Test fqversionnumber() function
+     */
+    public function test_fqversionnumber() {
+        $qv = new variables();
+        $errmsg = null;
+        try {
+            $v = $qv->vstack_create();
+            $result = $qv->evaluate_assignments($v, 'a=fqversionnumber();');
+        } catch (Exception $e) {
+            $errmsg = $e->getMessage();
+        }
+        $this->assertNull($errmsg);
+        $this->assertEquals(get_config('qtype_formulas')->version, $result->all['a']->value);
+    }
+
+
 }

--- a/variables.php
+++ b/variables.php
@@ -60,6 +60,15 @@ function fact($n) {
 }
 
 /**
+ * Return the plugin's version number.
+ *
+ * @return integer
+ */
+function fqversionnumber() {
+    return get_config('qtype_formulas')->version;
+}
+
+/**
  * calculate standard normal probability density
  *
  * @author Philipp Imhof
@@ -350,7 +359,7 @@ class variables {
     private static $listmaxsize = 1000;
 
     private function initialize_function_list() {
-        $this->func_const = array_flip( array('pi'));
+        $this->func_const = array_flip( array('pi', 'fqversionnumber'));
         $this->func_unary = array_flip( array('abs', 'acos', 'acosh', 'asin', 'asinh', 'atan', 'atanh', 'ceil',
             'cos', 'cosh' , 'deg2rad', 'exp', 'expm1', 'floor', 'is_finite', 'is_infinite', 'is_nan',
             'log10', 'log1p', 'rad2deg', 'sin', 'sinh', 'sqrt', 'tan', 'tanh', 'log', 'round', 'fact',
@@ -1948,6 +1957,7 @@ class variables {
                     break;
 
                 // Zero argument functions.
+                case 'fqversionnumber':
                 case 'pi':
                     if (strlen($regs[3]) != 0) {
                         return get_string('functiontakesnoargs', 'qtype_formulas', $regs[2]);


### PR DESCRIPTION
Users without admin permissions cannot know what version of Formulas Question they are running. However, that might be useful in some cases. The function `fqversionnumber()` will print the version number (not the release name). The name is deliberately chosen to be long, to avoid conflicts with existing user variables. After all, that function will probably not be used very often. 