### PR TITLE
Further improvement for the poly() function

### DIFF
--- a/tests/functions_test.php
+++ b/tests/functions_test.php
@@ -1006,6 +1006,10 @@ class functions_test extends \advanced_testcase {
             array('p=poly(["x", "y", "z"], [0, 0, 1], "&&");', '&&&&z'),
             array('p=poly(["x", "y", "z"], [0, 0, -1], "&&");', '&&&-&z'),
             array('p=poly(["x", "y", "z"], [0, 0, 0], "&&");', '&&&&0'),
+            // Separator with even length, but not doubled; no practical use...
+            array('p=poly(["x", "y", "z"], [1, -2, 3], "&#");', 'x&#-2y&#+3z'),
+            // Artificially making the lengh odd; no practical use...
+            array('p=poly(["x", "y", "z"], [1, -2, 3], "&& ");', 'x&& -2y&& +3z'),
         );
         foreach ($testcases as $case) {
             $qv = new variables;

--- a/tests/functions_test.php
+++ b/tests/functions_test.php
@@ -1000,7 +1000,7 @@ class functions_test extends \advanced_testcase {
             array('p=poly(["x", "y", "z"], [1, 2, 3], "&&");', 'x&+&2y&+&3z'),
             array('p=poly(["x", "y", "z"], [-1, -1, -1], "&&");', '-x&-&y&-&z'),
             array('p=poly(["x", "y", "z"], [-1, -2, -3], "&&");', '-x&-&2y&-&3z'),
-            array('p=poly(["x", "y", "z"], [0, 1, 1], "&&");', '&+&y&+&z'),
+            array('p=poly(["x", "y", "z"], [0, 1, 1], "&&");', '&&y&+&z'),
             array('p=poly(["x", "y", "z"], [1, 0, 1], "&&");', 'x&&&+&z'),
             array('p=poly(["x", "y", "z"], [1, 1, 0], "&&");', 'x&+&y&&'),
             array('p=poly(["x", "y", "z"], [0, 0, 1], "&&");', '&&&&z'),

--- a/tests/functions_test.php
+++ b/tests/functions_test.php
@@ -979,7 +979,7 @@ class functions_test extends \advanced_testcase {
             array('p=poly([1, 2, 3]);', 'x^{2}+2x+3'),
             array('p=poly([-1, -2, -3]);', '-x^{2}-2x-3'),
             array('p=poly([-1, -2, -3], "&");', '-x^{2}&-2x&-3'),
-            array('p=poly([0, 1], "&");', '&+1'),
+            array('p=poly([0, 1], "&");', '&1'),
             array('p=poly([1, 0, 1], "&");', 'x^{2}&&+1'),
             array('p=poly([1, 0, 0, 1], "&");', 'x^{3}&&&+1'),
             // With a list of variables and coefficients...
@@ -994,7 +994,18 @@ class functions_test extends \advanced_testcase {
             array('p=poly("", [1, -1, 1, -1], "&");', '1&-1&1&-1'),
             array('p=poly("", [0, 0, 0, 0], "&");', '0&0&0&0'),
             array('p=poly("", [1, 0, 2, 3], "&");', '1&0&2&3'),
-            array('p=poly("", [0, 1, 0, -1], "&");', '0&1&0&-1')
+            array('p=poly("", [0, 1, 0, -1], "&");', '0&1&0&-1'),
+            // With double separators for e.g. equation systems...
+            array('p=poly(["x", "y", "z"], [1, 1, 1], "&&");', 'x&+&y&+&z'),
+            array('p=poly(["x", "y", "z"], [1, 2, 3], "&&");', 'x&+&2y&+&3z'),
+            array('p=poly(["x", "y", "z"], [-1, -1, -1], "&&");', '-x&-&y&-&z'),
+            array('p=poly(["x", "y", "z"], [-1, -2, -3], "&&");', '-x&-&2y&-&3z'),
+            array('p=poly(["x", "y", "z"], [0, 1, 1], "&&");', '&+&y&+&z'),
+            array('p=poly(["x", "y", "z"], [1, 0, 1], "&&");', 'x&&&+&z'),
+            array('p=poly(["x", "y", "z"], [1, 1, 0], "&&");', 'x&+&y&&'),
+            array('p=poly(["x", "y", "z"], [0, 0, 1], "&&");', '&&&&z'),
+            array('p=poly(["x", "y", "z"], [0, 0, -1], "&&");', '&&&-&z'),
+            array('p=poly(["x", "y", "z"], [0, 0, 0], "&&");', '&&&&0'),
         );
         foreach ($testcases as $case) {
             $qv = new variables;

--- a/variables.php
+++ b/variables.php
@@ -360,8 +360,8 @@ function poly($variables, $coefficients = null, $forceplus = '', $additionalsepa
         $result = $forceplus . substr($result, 1);
     }
     // If we have nothing but separators before the leading +, replace that + by $forceplus.
-    if ($additionalseparator !== '' && preg_match("/^($additionalseparator+)\+/", $result)) {
-        $result = preg_replace("/^($additionalseparator+)\+/", "\\1$forceplus", $result);
+    if ($separatorbefore !== '' && preg_match("/^($separatorbefore+)\+/", $result)) {
+        $result = preg_replace("/^($separatorbefore+)\+/", "\\1$forceplus", $result);
     }
     return $result;
 }


### PR DESCRIPTION
When using `poly()` (with the new optional separator) to format a polynomial for an equation system, the output is much more beautiful if there is a separator before *and* after the operator:

![neatly aligned system of equations](https://user-images.githubusercontent.com/52650214/202895921-2fa3e6aa-2cc3-4e6d-87f1-626bffbc9375.png)

Without this extension, the system would look like this:

![original alignment](https://user-images.githubusercontent.com/52650214/202895983-7d42074f-f7a7-4265-8f6f-4ab663d6bd36.png)

To use this additional feature, one can simply double the separator when calling `poly()`, e.g. 
```
poly(["x", "y", "z"], [1, 1, 1], "&&")    => "x&+&y&+&z"
poly(["x", "y", "z"], [1, 2, 3], "&&")    => "x&+&2y&+&3z"
poly(["x", "y", "z"], [-1, -1, -1], "&&") => "-x&-&y&-&z"
poly(["x", "y", "z"], [-1, -2, -3], "&&") => "-x&-&2y&-&3z"
poly(["x", "y", "z"], [0, 1, 1], "&&")    => "&&y&+&z"
poly(["x", "y", "z"], [1, 0, 1], "&&")    => "x&&&+&z"
poly(["x", "y", "z"], [1, 1, 0], "&&")    => "x&+&y&&"
poly(["x", "y", "z"], [0, 0, 1], "&&")    => "&&&&z"
poly(["x", "y", "z"], [0, 0, -1], "&&")   => "&&&-&z"
poly(["x", "y", "z"], [0, 0, 0], "&&")    => "&&&&0"
```

The function automatically detects if the separator is doubled and then splits it around the operator. If one would really want to have `&&` as a separator (for whatever reason), they can still have that by simply using `& &` with a space: spaces are ignored by MathJax.