### PR TITLE
Bugfix for instantiation check

### DIFF
--- a/classes/external/instantiation.php
+++ b/classes/external/instantiation.php
@@ -134,7 +134,7 @@ class instantiation extends \external_api {
                 $row['parts'][$i][] = array('name' => '_0', 'value' => '!!!');
                 break;
             }
-            if (gettype($evaluatedanswers[$i]->value) == 'string') {
+            if (is_scalar($evaluatedanswers[$i]->value)) {
                 $row['parts'][$i][] = array('name' => '_0', 'value' => $evaluatedanswers[$i]->value);
                 continue;
             }

--- a/tests/externallib_test.php
+++ b/tests/externallib_test.php
@@ -251,6 +251,58 @@ class externallib_test extends \externallib_advanced_testcase {
             array(
                 'n' => 1,
                 'randomvars' => '',
+                'globalvars' => 'a=3; b=2; c=a*b',
+                'localvars' => array(''),
+                'answers' => array('a*b'),
+                'return' => array(
+                    'status' => 'ok',
+                    'data' => array(
+                        array(
+                            'randomvars' => array(),
+                            'globalvars' => array(
+                                array('name' => 'a', 'value' => '3'),
+                                array('name' => 'b', 'value' => '2'),
+                                array('name' => 'c', 'value' => '6')
+                            ),
+                            'parts' => array(
+                                array(
+                                    array('name' => '_0', 'value' => '6'),
+                                )
+                            ),
+                        )
+                    )
+                )
+            ),
+            array(
+                'n' => 1,
+                'randomvars' => '',
+                'globalvars' => 'a=3; b=2; c=a*b',
+                'localvars' => array(''),
+                'answers' => array('[a*b,c,6]'),
+                'return' => array(
+                    'status' => 'ok',
+                    'data' => array(
+                        array(
+                            'randomvars' => array(),
+                            'globalvars' => array(
+                                array('name' => 'a', 'value' => '3'),
+                                array('name' => 'b', 'value' => '2'),
+                                array('name' => 'c', 'value' => '6')
+                            ),
+                            'parts' => array(
+                                array(
+                                    array('name' => '_0', 'value' => '6'),
+                                    array('name' => '_1', 'value' => '6'),
+                                    array('name' => '_2', 'value' => '6'),
+                                )
+                            ),
+                        )
+                    )
+                )
+            ),
+            array(
+                'n' => 1,
+                'randomvars' => '',
                 'globalvars' => 'a={1,2,3}',
                 'localvars' => array(''),
                 'answers' => array('1'),

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_formulas';
-$plugin->version   = 2022112700;
+$plugin->version   = 2023010400;
 
 $plugin->cron      = 0;
 $plugin->requires  = 2017111300;
@@ -35,6 +35,6 @@ $plugin->dependencies = array(
     'qtype_multichoice' => 2015111600,
 );
 $plugin->supported = [39, 401];
-$plugin->release   = '5.1.0 for Moodle 3.9+';
+$plugin->release   = '5.1.1 for Moodle 3.9+';
 
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
As reported in #63, instantiation check can fail in certain cases. 

This is due to the fact that the code checks whether there is one answer (`_0`) or a list of *n* answers (`_0` … `_n`). Currently, the check is done by looking at the data type of the evaluated answer. If it is a `string`, it's only one answer. However, in some cases (i. e. the answer being an expression instead of a constant number), the type can be `float` or `double`. The old check did not consider these cases and assumed there were multiple answers instead.

This PR fixes the problem by checking whether the evaluated answer is scalar.

I suggest doing a bugfix release right after the review.