### PR TITLE
Fix bug in function sort()

### DIFF
--- a/tests/variables_test.php
+++ b/tests/variables_test.php
@@ -212,9 +212,29 @@ class variables_test extends \advanced_testcase {
                     's' => (object) array('type' => 'ln', 'value' => array(2, 3, 5, 7, 11)),
                     )
             ),
+            array(true, 's=sort([1,10,5,3]);', array(
+                    's' => (object) array('type' => 'ln', 'value' => array(1, 3, 5, 10)),
+                    )
+            ),
+            array(true, 's=sort(["4","3","A","a","B","2","1","b","c","C"]);', array(
+                    's' => (object) array('type' => 'ls', 'value' => ['1','2','3','4','A','B','C','a','b','c']),
+                    )
+            ),
+            array(true, 's=sort(["B","C","A","B"]);', array(
+                    's' => (object) array('type' => 'ls', 'value' => array('A', 'B', 'B', 'C')),
+                    )
+            ),
+            array(true, 's=sort(["B","3","1","0","A","C","c","b","2","a"]);', array(
+                    's' => (object) array('type' => 'ls', 'value' => array('0','1','2','3','A','B','C','a','b','c')),
+                    )
+            ),
             array(true, 's=sort(["B","A2","A1"]);', array(
                     's' => (object) array('type' => 'ls', 'value' => array('A1', 'A2', 'B')),
                     )
+            ),
+            array(true, 's=sort(["B","C","A"],[0,2,1]);', array(
+                's' => (object) array('type' => 'ls', 'value' => array('B', 'A', 'C')),
+                )
             ),
             array(true, 's=sort(["B","A2","A1"],[2,4,1]);', array(
                     's' => (object) array('type' => 'ls', 'value' => array('A1', 'B', 'A2')),

--- a/tests/variables_test.php
+++ b/tests/variables_test.php
@@ -212,6 +212,14 @@ class variables_test extends \advanced_testcase {
                     's' => (object) array('type' => 'ln', 'value' => array(2, 3, 5, 7, 11)),
                     )
             ),
+            array(true, 's=sort(["A1","A10","A2","A100"]);', array(
+                    's' => (object) array('type' => 'ls', 'value' => array("A1", "A2", "A10", "A100")),
+                    )
+            ),
+            array(true, 's=sort([1,2,3], ["A10","A1","A2"]);', array(
+                    's' => (object) array('type' => 'ln', 'value' => array(2, 3, 1)),
+                    )
+            ),
             array(true, 's=sort([1,10,5,3]);', array(
                     's' => (object) array('type' => 'ln', 'value' => array(1, 3, 5, 10)),
                     )

--- a/tests/variables_test.php
+++ b/tests/variables_test.php
@@ -240,6 +240,10 @@ class variables_test extends \advanced_testcase {
                     's' => (object) array('type' => 'ls', 'value' => array('A1', 'B', 'A2')),
                     )
             ),
+            array(true, 's=sort(["A","B","C"],["A2","A10","A1"]);', array(
+                    's' => (object) array('type' => 'ls', 'value' => array('C', 'A', 'B')),
+                    )
+            ),
             array(true, 's=sublist(["A","B","C","D"],[1,3]);', array(
                     's' => (object) array('type' => 'ls', 'value' => array('B', 'D')),
                     )

--- a/variables.php
+++ b/variables.php
@@ -1310,10 +1310,7 @@ class variables {
                 $tmp = $values[0];
                 $order = $values[1];
                 uksort($tmp, function($a, $b) use ($order) {
-                    if ($order[$a] === $order[$b]) {
-                        return 0;
-                    }
-                    return ($order[$a] > $order[$b] ? 1 : -1);
+                    return strnatcmp($order[$a], $order[$b]);
                 });
                 $this->replace_middle($vstack, $expression, $l, $r, $types[0], array_values($tmp));
                 return true;

--- a/variables.php
+++ b/variables.php
@@ -1296,13 +1296,25 @@ class variables {
                     break;
                 }
                 if ($sz == 1) {
-                    $values[1] = $values[0];
+                    // If we have one list, we use natural sorting.
+                    $tmp = $values[0];
+                    natsort($tmp);
+                    $this->replace_middle($vstack, $expression, $l, $r, $types[0], array_values($tmp));
+                    return true;
                 }
                 if (mycount($values[0]) != mycount($values[1])) {
                     break;
                 }
-                $tmp = array_combine($values[1], $values[0]);
-                ksort($tmp);
+                // Still here? That means we have two lists of the same size. Use the latter
+                // as the sort order.
+                $tmp = $values[0];
+                $order = $values[1];
+                uksort($tmp, function($a, $b) use ($order) {
+                    if ($order[$a] === $order[$b]) {
+                        return 0;
+                    }
+                    return ($order[$a] > $order[$b] ? 1 : -1);
+                });
                 $this->replace_middle($vstack, $expression, $l, $r, $types[0], array_values($tmp));
                 return true;
             case 'sublist':

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_formulas';
-$plugin->version   = 2023010400;
+$plugin->version   = 2023010800;
 
 $plugin->cron      = 0;
 $plugin->requires  = 2017111300;


### PR DESCRIPTION
fixes #48 

```
sort([7, 5, 3, 11, 2]) => [2, 3, 5, 7, 11]
sort([1, 10, 5, 3]) => [1, 3, 5, 10]
sort(["4", "3", "A", "a", "B", "2", "1", "b", "c", "C"]) => ['1', '2', '3', '4', 'A', 'B', 'C', 'a', 'b', 'c']
sort(["B", "C", "A", "B"]) => ['A', 'B', 'B', 'C']
sort(["B", "3", "1", "0", "A", "C", "c", "b", "2", "a"]) => ['0', '1', '2', '3', 'A', 'B', 'C', 'a', 'b', 'c']
sort(["B", "A2", "A1"]) => ['A1', 'A2', 'B']
sort(["B", "C", "A"], [0, 2, 1]) => ['B', 'A', 'C']
sort(["B", "A2", "A1"], [2, 4, 1]) => ['A1', 'B', 'A2']
```