### PR TITLE
implement fmod() like other scientific calculators

### DIFF
--- a/tests/functions_test.php
+++ b/tests/functions_test.php
@@ -1060,5 +1060,30 @@ class functions_test extends \advanced_testcase {
         $this->assertEquals(get_config('qtype_formulas')->version, $result->all['a']->value);
     }
 
+    public function test_fmod() {
+        $testcases = array(
+            array(fmod(35, 20), 15),
+            array(fmod(-35, 20), 5),
+            array(fmod(35, -20), -5),
+            array(fmod(-35, -20), -15),
+            array(fmod(12, 3), 0),
+            array(fmod(5, 8), 5),
+            array(fmod(5.7, 1.3), 0.5),
+            array(fmod(0, 7.9), 0),
+            array(fmod(2, 0.4), 0)
+        );
+        foreach ($testcases as $case) {
+            $this->assertEquals($case[1], $case[0]);
+        }
+        $qv = new variables();
+        $errmsg = null;
+        try {
+            $v = $qv->vstack_create();
+            $qv->evaluate_assignments($v, 'a=fmod(4, 0);');
+        } catch (Exception $e) {
+            $errmsg = $e->getMessage();
+        }
+        $this->assertEquals('1: ' . get_string('error_eval_numerical', 'qtype_formulas'), $errmsg);
+    }
 
 }

--- a/variables.php
+++ b/variables.php
@@ -171,6 +171,26 @@ function modinv($a, $m) {
     return ($s < 0) ? $s + $orig_m : $s;
 }
 
+/**
+ * Calculate the floating point remainder of the division of
+ * the arguments, i. e. x - m * floor(x / m). There is no
+ * canonical definition for this function; some calculators
+ * use flooring (round down to nearest integer) and others
+ * use truncation (round to nearest integer, but towards zero).
+ * This implementation gives the same results as e. g. Wolfram Alpha.
+ *
+ * @author Philipp Imhof
+ * @param float $x the dividend
+ * @param float $m the modulus
+ * @return float remainder of $x modulo $m
+ */
+function fmod($x, $m) {
+    if ($m === 0) {
+        throw new Exception(get_string('error_eval_numerical', 'qtype_formulas'));
+    }
+    return $x - $m * floor($x / $m);
+}
+
 function npr($n, $r) {
     $n = (int)$n;
     $r = (int)$r;


### PR DESCRIPTION
As mentioned in #46 and in the [docs](https://dynamiccourseware.org/course/view.php?id=31&section=30), the current implementation of `fmod()` gives unexpected results. Formulas Question currently uses PHP's built-in function to calculate the floating point remainder.

This PR brings a new implementation. Now, `fmod()` gives the same results as e.g. WolframAlpha or other scientific calculators.