### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -32,6 +32,8 @@ jobs:
         exclude:
           - moodle-branch: 'MOODLE_39_STABLE'
             php: '8.0'
+          - moodle-branch: 'master'
+            php: '7.4'
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0']
+        php: ['8.0']
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/phpmd.yml
+++ b/.github/workflows/phpmd.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['8.0', '8.1']
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -37,6 +37,8 @@ jobs:
         exclude:
           - moodle-branch: 'MOODLE_39_STABLE'
             php: '8.0'
+          - moodle-branch: 'master'
+            php: '7.4'
 
     steps:
       - name: Check out repository code


### PR DESCRIPTION
some of the automated checks are failing, namely because of new requirements:

- Postgres >= 13
- PHP >= 8.0 for Moodle's master branch