### PR TITLE
Modify automated grunt check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -89,4 +89,4 @@ jobs:
       - name: Grunt
         continue-on-error: true
         if: ${{ always() }}
-        run: moodle-plugin-ci grunt --max-lint-warnings 0
+        run: moodle-plugin-ci grunt --max-lint-warnings 1


### PR DESCRIPTION
As there is 1 ignored JS (from the Tabulator library), grunt will issue a warning. Thus, we should not have `--max-lint-warnings` set to 0.