### PR TITLE
Replace deprecated set-output command

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -49,7 +49,7 @@ jobs:
                                          --data-urlencode "vcstag=${TAGNAME}" \
                                          --data-urlencode "changelogurl=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commits/${TAGNAME}" \
                                          --data-urlencode "altdownloadurl=${ZIPURL}")
-          echo "::set-output name=response::${RESPONSE}"
+          echo "response=${RESPONSE}" >> $GITHUB_OUTPUT
 
       - name: Evaluate the response
         id: evaluate-response


### PR DESCRIPTION
according to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/