### PR TITLE
Update All SI Units

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- new feature: possiblity to enter µ (mu, and greek letter) in addition to u
+- new feature: conversion rules: add fullsiunit beside of commonsiunit and none.
+- removed: not used function get_unit_mapping(), and get_dimension_list()
+
 ### 5.2.0 (2023-03-17)
 - new functions: binomialpdf() and binomialcdf()
 - bugfix: gcd() now gives correct result even if one argument is 0

--- a/conversion_rules.php
+++ b/conversion_rules.php
@@ -29,25 +29,28 @@ class unit_conversion_rules {
     public function __construct() {
         $this->basicunitconversionrule[0] = array(get_string('none', 'qtype_formulas'), '');
         $this->basicunitconversionrule[1] = array(get_string('commonsiunit', 'qtype_formulas'), '
-m: k c d m u n p f;
-s: m u n p f;
-g: k m u n p f;
-mol: m u n p;
-N: k m u n p f;
-A: m u n p f;
-J: k M G T P m u n p f;
+m: k c d m u µ μ n p f;
+s: m u µ μ n p f;
+g: k m u µ μ n p f;
+mol: m u µ μ n p;
+N: k m u µ μ n p f;
+A: k m u µ μ n p f;
+J: k M G T P m u µ μ n p f;
 J = 6.24150947e+18 eV;
-eV: k M G T P m u;
-W: k M G T P m u n p f;
+eV: k M G T P m u µ μ;
+W: k M G T P m u µ μ n p f;
 Pa: k M G T P;
 Hz: k M G T P E;
-C: k m u n p f;
-V: k M G m u n p f;
+C: k m u µ μ n p f;
+V: k M G m u µ μ n p f;
 ohm: m k M G T P;
-F: m u n p f;
-T: k m u n p;
-H: k m u n p;
+Ω: u µ μ m k M G T P;
+F: m u µ μ n p f;
+T: k m u µ μ n p;
+H: k m u µ μ n p;
 ');
+
+        $this->basicunitconversionrule[2] = array(get_string('allsiunits', 'qtype_formulas'), '');
 
         /* You can define your own rules here, for instance:
          * $this->basicunitconversionrule[100] = array(

--- a/lang/en/qtype_formulas.php
+++ b/lang/en/qtype_formulas.php
@@ -168,10 +168,14 @@ $string['ruleid'] = 'Basic conversion rules';
 $string['ruleid_help'] = 'This question type has a build-in unit conversion system and has basic conversion rules.
 
 The basic one is the "Common SI unit" rules that will convert standard units
-such as unit for length, say, km, m, cm and mm. This option has no
-effect if no unit has been used.';
+such as unit for length, say, km, m, cm and mm.
+The "All SI units" rules converts all given units with its SI prefixes including u and µ (Greek letter),
+see https://en.wikipedia.org/wiki/Metric_prefix.
+Those options have no effect if no unit has been used.';
+
 $string['none'] = 'None';
 $string['commonsiunit'] = 'Common SI unit';
+$string['allsiunits'] = 'All SI units';
 $string['otherrule'] = 'Other rules';
 $string['otherrule_help'] = 'Here the question\' author can define additional  conversion rules for other accepted base units. See documentation for the advanced usages.';
 $string['subqtext'] = 'Part\'s text';

--- a/question.php
+++ b/question.php
@@ -619,7 +619,7 @@ class qtype_formulas_question extends question_graded_automatically_with_countba
         // Step 2: Use the unit system to check whether the unit in student responses is *convertible* to the true unit.
         $conversionrules = new unit_conversion_rules;
         $entry = $conversionrules->entry($part->ruleid);
-        $checkunit->assign_default_rules($part->ruleid, $entry[1]);
+        $checkunit->assign_default_rules($part->ruleid, $entry[1], $part->postunit);
         $checkunit->assign_additional_rules($part->otherrule);
         $checked = $checkunit->check_convertibility($postunit, $part->postunit);
         $cfactor = $checked->cfactor;

--- a/questiontype.php
+++ b/questiontype.php
@@ -913,7 +913,7 @@ class qtype_formulas extends question_type {
                 if ($entry === null || $entry[1] === null) {
                     throw new Exception(get_string('error_ruleid', 'qtype_formulas'));
                 }
-                $unitcheck->assign_default_rules($ans->ruleid, $entry[1]);
+                $unitcheck->assign_default_rules($ans->ruleid, $entry[1], $ans->postunit);
                 $unitcheck->reparse_all_rules();
             } catch (Exception $e) {
                 $errors["ruleid[$idx]"] = $e->getMessage();

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_formulas';
-$plugin->version = 2023031700;
+$plugin->version = 2023040500;
 
 $plugin->cron = 0;
 $plugin->requires = 2017111300;


### PR DESCRIPTION
I have been annoyed for a very long time that you can't just use all the units with the SI prefixes. For the electronics lectures at the university of applied sciences I asked students to use the scientific notation for the time being. Then I moved on to using conversion formulas. Long story short:
I implemented a third choice at the "Unit Settings "+"Basic conversion rules" called "All SI units". With this setting, for any unit, the possibility to enter all SI prefixes is given. 
Example: Unit "**µA**" given. As a result from a question you have to enter e.g. "**22 µA**".
Now, with this "All SI units" - setting, all these answers are correct:

- 22 µA
- 0.022 mA
- 22e-6 A
- 22000 pA
- 22 uA

Additionally this functionality works with any unit e.g. kΩ, VA, kmol, mol, cd, ...

- new feature: possiblity to enter µ (mu, and greek letter) in addition to u
- new feature: conversion rules: add fullsiunit beside of commonsiunit and none.
- removed: not used function get_unit_mapping(), and get_dimension_list()