### PR TITLE
Prepare for Moodle 4.2

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.4', '8.0', '8.1']
-        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'MOODLE_401_STABLE', 'master']
+        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'master']
         database: [mariadb]
         exclude:
           - moodle-branch: 'MOODLE_39_STABLE'
@@ -38,6 +38,8 @@ jobs:
             php: '8.1'
           - moodle-branch: 'MOODLE_400_STABLE'
             php: '8.1'
+          - moodle-branch: 'MOODLE_402_STABLE'
+            php: '7.4'
           - moodle-branch: 'master'
             php: '7.4'
 

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -26,12 +26,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0']
+        php: ['7.4', '8.0', '8.1']
         moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'MOODLE_401_STABLE', 'master']
         database: [mariadb]
         exclude:
           - moodle-branch: 'MOODLE_39_STABLE'
             php: '8.0'
+          - moodle-branch: 'MOODLE_39_STABLE'
+            php: '8.1'
+          - moodle-branch: 'MOODLE_311_STABLE'
+            php: '8.1'
+          - moodle-branch: 'MOODLE_400_STABLE'
+            php: '8.1'
           - moodle-branch: 'master'
             php: '7.4'
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0']
+        php: ['8.0', '8.1']
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.4', '8.0', '8.1']
-        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'MOODLE_401_STABLE', 'master']
+        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'master']
         database: [pgsql, mariadb]
         exclude:
           - moodle-branch: 'MOODLE_39_STABLE'
@@ -43,6 +43,8 @@ jobs:
             php: '8.1'
           - moodle-branch: 'MOODLE_400_STABLE'
             php: '8.1'
+          - moodle-branch: 'MOODLE_402_STABLE'
+            php: '7.4'
           - moodle-branch: 'master'
             php: '7.4'
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,12 +31,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0']
+        php: ['7.4', '8.0', '8.1']
         moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'MOODLE_401_STABLE', 'master']
         database: [pgsql, mariadb]
         exclude:
           - moodle-branch: 'MOODLE_39_STABLE'
             php: '8.0'
+          - moodle-branch: 'MOODLE_39_STABLE'
+            php: '8.1'
+          - moodle-branch: 'MOODLE_311_STABLE'
+            php: '8.1'
+          - moodle-branch: 'MOODLE_400_STABLE'
+            php: '8.1'
           - moodle-branch: 'master'
             php: '7.4'
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 5.2.1 (2023-04-22)
+- assure compatibility with Moodle 4.2
+- internal: changes for compatibility with PHP 8.1
+- internal: add PHP 8.1 to CI test matrix
+- internal: added tests for units
+
 ### 5.2.0 (2023-03-17)
 - new functions: binomialpdf() and binomialcdf()
 - bugfix: gcd() now gives correct result even if one argument is 0

--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ still available at the [original author's website](https://code.google.com/p/moo
 at the date of this writing. It was then upgraded to the new question engine introduced in Moodle 2.1 by
 Jean-Michel Védrine.
 
-This version is compatible with Moodle 3.9 and newer. It has been tested with Moodle
-versions 3.9, 3.11, 4.0 and 4.1. It has also been tested with PHP versions 7.4 and 8.0.
+This version is compatible with Moodle 3.9 and newer. It has been tested with:
+- Moodle 3.9 using PHP 7.4
+- Moodle 3.11 using PHP 7.4 and PHP 8.0
+- Moodle 4.0 using PHP 7.4 and PHP 8.0
+- Moodle 4.1 using PHP 7.4, PHP 8.0 and PHP 8.1
+- Moodle 4.2 using PHP 8.0 and PHP 8.1
 
 
 ### Requirements

--- a/tests/externallib_test.php
+++ b/tests/externallib_test.php
@@ -29,12 +29,15 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/webservice/tests/helpers.php');
-require_once($CFG->dirroot . '/question/type/formulas/classes/external/instantiation.php');
 
 class externallib_test extends \externallib_advanced_testcase {
+    public function setUp(): void {
+        global $CFG;
+        require_once($CFG->dirroot . '/question/type/formulas/classes/external/instantiation.php');
+    }
 
     /**
-     * Test
+     * @runInSeparateProcess
      */
     public function test_check_random_global_vars() {
         $this->resetAfterTest(true);
@@ -72,6 +75,9 @@ class externallib_test extends \externallib_advanced_testcase {
         }
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function test_check_local_vars() {
         $this->resetAfterTest(true);
 
@@ -147,6 +153,9 @@ class externallib_test extends \externallib_advanced_testcase {
         }
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function test_render_question_text() {
         $this->resetAfterTest(true);
 
@@ -244,6 +253,9 @@ class externallib_test extends \externallib_advanced_testcase {
         }
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function test_instantiate() {
         $this->resetAfterTest(true);
 

--- a/tests/externallib_test.php
+++ b/tests/externallib_test.php
@@ -30,15 +30,15 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once($CFG->dirroot . '/webservice/tests/helpers.php');
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class externallib_test extends \externallib_advanced_testcase {
     public function setUp(): void {
         global $CFG;
         require_once($CFG->dirroot . '/question/type/formulas/classes/external/instantiation.php');
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function test_check_random_global_vars() {
         $this->resetAfterTest(true);
 
@@ -75,9 +75,6 @@ class externallib_test extends \externallib_advanced_testcase {
         }
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function test_check_local_vars() {
         $this->resetAfterTest(true);
 
@@ -153,9 +150,6 @@ class externallib_test extends \externallib_advanced_testcase {
         }
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function test_render_question_text() {
         $this->resetAfterTest(true);
 
@@ -253,9 +247,6 @@ class externallib_test extends \externallib_advanced_testcase {
         }
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function test_instantiate() {
         $this->resetAfterTest(true);
 

--- a/variables.php
+++ b/variables.php
@@ -651,9 +651,13 @@ class variables {
     // Return the text with the variables, or evaluable expressions, substituted by their values.
     public function substitute_variables_in_text(&$vstack, $text) {
         $funcpattern = '/(\{=[^{}]+\}|\{([A-Za-z][A-Za-z0-9_]*)(\[([0-9]+)\])?\})/';
-        $results = array();
-        // @codingStandardsIgnoreLine
-        $ts = explode("\n`", $text);     // The ` is the separator, so split it first.
+        $results = [];
+        if (is_string($text)) {
+            // @codingStandardsIgnoreLine
+            $ts = explode("\n`", $text);     // The ` is the separator, so split it first.
+        } else {
+            $ts = [];
+        }
         foreach ($ts as $text) {
             // @codingStandardsIgnoreLine
             $splitted = explode("\n`", preg_replace($funcpattern, "\n`$1\n`", $text));
@@ -715,7 +719,11 @@ class variables {
 
     // Replace the strings in the $text.
     private function substitute_strings_by_placholders(&$vstack, $text) {
-        $text = stripcslashes($text);
+        if (is_string($text)) {
+            $text = stripcslashes($text);
+        } else {
+            $text = '';
+        }
         $splitted = explode("\"", $text);
         if (mycount($splitted) % 2 == 0) {
             throw new Exception(get_string('error_vars_string', 'qtype_formulas'));

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_formulas';
-$plugin->version = 2023031700;
+$plugin->version = 2023042200;
 
 $plugin->cron = 0;
 $plugin->requires = 2017111300;
@@ -34,7 +34,7 @@ $plugin->dependencies = array(
     'qbehaviour_adaptivemultipart' => 2014092500,
     'qtype_multichoice' => 2015111600,
 );
-$plugin->supported = [39, 401];
-$plugin->release = '5.2.0 for Moodle 3.9+';
+$plugin->supported = [39, 402];
+$plugin->release = '5.2.1 for Moodle 3.9+';
 
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_formulas';
-$plugin->version = 2023042200;
+$plugin->version = 2023042400;
 
 $plugin->cron = 0;
 $plugin->requires = 2017111300;


### PR DESCRIPTION
- Add PHP 8.1 to the testing matrix, as that version will be supported by Moodle 4.2. (It can also be used with Moodle 4.1.2 and newer versions.)
- Make necessary changes in order for Formulas Question to properly work with PHP 8.1.
- Assure compatibility with Moodle 4.2, e.g. moved External API