### PR TITLE
change sort() order for negative numbers

### DIFF
--- a/tests/variables_test.php
+++ b/tests/variables_test.php
@@ -252,6 +252,14 @@ class variables_test extends \advanced_testcase {
                     's' => (object) array('type' => 'ls', 'value' => array('C', 'A', 'B')),
                     )
             ),
+            array(true, 's=sort([-3,-2,4,2,3,1,0,-1,-4,5]);', array(
+                    's' => (object) array('type' => 'ln', 'value' => array(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5)),
+                    )
+            ),
+            array(true, 's=sort(["-3","-2","B","2","3","1","0","-1","b","a","A"]);', array(
+                    's' => (object) array('type' => 'ls', 'value' => array('-3', '-2', '-1', '0', '1', '2', '3', 'A', 'B', 'a', 'b')),
+                    )
+            ),
             array(true, 's=sublist(["A","B","C","D"],[1,3]);', array(
                     's' => (object) array('type' => 'ls', 'value' => array('B', 'D')),
                     )

--- a/variables.php
+++ b/variables.php
@@ -1377,11 +1377,8 @@ class variables {
                     break;
                 }
                 if ($sz == 1) {
-                    // If we have one list, we use natural sorting.
-                    $tmp = $values[0];
-                    natsort($tmp);
-                    $this->replace_middle($vstack, $expression, $l, $r, $types[0], array_values($tmp));
-                    return true;
+                    // If we have one list, we duplicate it.
+                    $values[1] = $values[0];
                 }
                 if (mycount($values[0]) != mycount($values[1])) {
                     break;
@@ -1391,7 +1388,14 @@ class variables {
                 $tmp = $values[0];
                 $order = $values[1];
                 uksort($tmp, function($a, $b) use ($order) {
-                    return strnatcmp($order[$a], $order[$b]);
+                    $first = $order[$a];
+                    $second = $order[$b];
+                    // If both elements are numeric, we compare their numerical value.
+                    if (is_numeric($first) && is_numeric($second)) {
+                        return floatval($first) <=> floatval($second);
+                    }
+                    // Otherwise, we use natural sorting.
+                    return strnatcmp($first, $second);
                 });
                 $this->replace_middle($vstack, $expression, $l, $r, $types[0], array_values($tmp));
                 return true;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_formulas';
-$plugin->version = 2023042400;
+$plugin->version = 2023050600;
 
 $plugin->cron = 0;
 $plugin->requires = 2017111300;
@@ -35,6 +35,6 @@ $plugin->dependencies = array(
     'qtype_multichoice' => 2015111600,
 );
 $plugin->supported = [39, 402];
-$plugin->release = '5.2.1 for Moodle 3.9+';
+$plugin->release = '5.2.1+ for Moodle 3.9+';
 
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Currently, `sort()` uses natural sorting, as introduced in 5.1.1.

However, as noted in #48, natural sort order is counter-intuitive when it comes to negative numbers, because they are sorted according to their absolute value, e.g. `[1,3,-2,-5,4]` will be sorted as `[-2,-5,1,3,4]`, cf. [PHP docs](https://www.php.net/manual/en/function.natsort.php).

With this change, we use natural sorting among strings or when comparing a string to a number (which is not possible in the current version of Formulas Question, but it will be available in an upcoming release, when the same list may contain a mix of numbers and strings). If, however, we compare to numbers or numeric strings, we use numerical sorting.