### PR TITLE
fix overloaded property raw_grades

### DIFF
--- a/question.php
+++ b/question.php
@@ -57,6 +57,7 @@ class qtype_formulas_question extends question_graded_automatically_with_countba
     /** These array may be used some day to store results ? */
     public $evaluatedanswer = array();
     public $fractions = array();
+    public $raw_grades = array();
     public $anscorrs = array();
     public $unitcorrs = array();
 


### PR DESCRIPTION
Legacy code uses overloaded property qtype_formulas_question::raw_grades. This causes an error with Moodle 4.3+ and makes unit tests fail.