### PR TITLE
Better feedback when correct answer is unique

### DIFF
--- a/backup/moodle2/backup_qtype_formulas_plugin.class.php
+++ b/backup/moodle2/backup_qtype_formulas_plugin.class.php
@@ -55,7 +55,7 @@ class backup_qtype_formulas_plugin extends backup_qtype_plugin {
 
         $formulasanswers = new backup_nested_element('formulas_answers');
         $formulasanswer = new backup_nested_element('formulas_answer', array('id'), array(
-            'placeholder', 'answermark', 'answertype', 'numbox', 'vars1', 'answer', 'vars2', 'correctness',
+            'placeholder', 'answermark', 'answertype', 'numbox', 'vars1', 'answer', 'answernotunique', 'vars2', 'correctness',
             'unitpenalty', 'postunit', 'ruleid', 'otherrule', 'subqtext', 'subqtextformat', 'feedback', 'feedbackformat',
             'partcorrectfb', 'partcorrectfbformat',
             'partpartiallycorrectfb', 'partpartiallycorrectfbformat',

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="question/type/formulas/db" VERSION="20130130" COMMENT="XMLDB file for Moodle question/type/formulas"
+<XMLDB PATH="question/type/formulas/db" VERSION="20230812" COMMENT="XMLDB file for Moodle question/type/formulas"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -35,6 +35,7 @@
         <FIELD NAME="numbox" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="vars1" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="answer" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="answernotunique" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
         <FIELD NAME="vars2" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="correctness" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="unitpenalty" TYPE="float" NOTNULL="false" SEQUENCE="false"/>

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="question/type/formulas/db" VERSION="20230812" COMMENT="XMLDB file for Moodle question/type/formulas"
+<XMLDB PATH="question/type/formulas/db" VERSION="20231008" COMMENT="XMLDB file for Moodle question/type/formulas"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -368,5 +368,22 @@ function xmldb_qtype_formulas_upgrade($oldversion=0) {
         // Formulas savepoint reached.
         upgrade_plugin_savepoint(true, 2018080300, 'qtype', 'formulas');
     }
+
+    if ($oldversion < 2023081200) {
+        // Define field answernotunique to be added to qtype_formulas_answers.
+        $table = new xmldb_table('qtype_formulas_answers');
+        $field = new xmldb_field('answernotunique', XMLDB_TYPE_INTEGER, '4', null, XMLDB_NOTNULL, null, '1', 'answer');
+
+        // Conditionally add field.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+            // Now fill it with '1' for compatibility with existing questions'.
+            $DB->set_field('qtype_formulas_answers', 'answernotunique', '1');
+        }
+
+        // Formulas savepoint reached.
+        upgrade_plugin_savepoint(true, 2023081200, 'qtype', 'formulas');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -369,7 +369,7 @@ function xmldb_qtype_formulas_upgrade($oldversion=0) {
         upgrade_plugin_savepoint(true, 2018080300, 'qtype', 'formulas');
     }
 
-    if ($oldversion < 2023081200) {
+    if ($oldversion < 2023100800) {
         // Define field answernotunique to be added to qtype_formulas_answers.
         $table = new xmldb_table('qtype_formulas_answers');
         $field = new xmldb_field('answernotunique', XMLDB_TYPE_INTEGER, '4', null, XMLDB_NOTNULL, null, '1', 'answer');
@@ -382,7 +382,7 @@ function xmldb_qtype_formulas_upgrade($oldversion=0) {
         }
 
         // Formulas savepoint reached.
-        upgrade_plugin_savepoint(true, 2023081200, 'qtype', 'formulas');
+        upgrade_plugin_savepoint(true, 2023100800, 'qtype', 'formulas');
     }
 
     return true;

--- a/edit_formulas_form.php
+++ b/edit_formulas_form.php
@@ -153,6 +153,13 @@ class qtype_formulas_edit_form extends question_edit_form {
             array('size' => 80));
         $repeatedoptions['answer']['helpbutton'] = array('answer', 'qtype_formulas');
         $repeatedoptions['answer']['type'] = PARAM_RAW;
+        // Whether the question has multiple answers.
+        $repeated[] = $mform->createElement(
+            'advcheckbox',
+            'answernotunique',
+            get_string('answernotunique', 'qtype_formulas')
+        );
+        $repeatedoptions['answernotunique']['helpbutton'] = array('answernotunique', 'qtype_formulas');
         // Part's unit.
         $repeated[] = $mform->createElement('text', 'postunit', get_string('postunit', 'qtype_formulas'),
             array('size' => 60, 'class' => 'formulas_editing_unit'));

--- a/lang/en/qtype_formulas.php
+++ b/lang/en/qtype_formulas.php
@@ -118,6 +118,8 @@ $string['vars1'] = 'Local variables';
 $string['vars1_help'] = 'You can define variables here in the same way as global variables are defined at the question level. Variables defined here can be used in the part\'s answer or feedback
 and their scope of visibility is limited to the part.';
 $string['answer'] = 'Answer*';
+$string['answernotunique'] = 'There are other correct answers.';
+$string['answernotunique_help'] = 'If this option is checked, the student will see "One correct answer is: ..." instead of "The correct answer is: ..." when reviewing their attempt.';
 $string['answercombinedunitmulti'] = 'Answer and unit for part {$a->part}';
 $string['answercombinedunitsingle'] = 'Answer and unit';
 $string['answercoordinatemulti'] = 'Answer field {$a->numanswer} for part {$a->part}';
@@ -246,6 +248,7 @@ $string['error_grading_error'] = 'Grading error! Probably result of incorrect im
 
 // The language strings for the renderer.
 $string['correctansweris'] = 'One possible correct answer is: {$a}';
+$string['uniquecorrectansweris'] = 'The correct answer is: {$a}';
 
 // String that were "borrowed" from quiz and are now in calculated plugin.
 $string['illegalformulasyntax'] = 'Illegal formula syntax starting with \'{$a}\'';

--- a/question.php
+++ b/question.php
@@ -930,6 +930,7 @@ class qtype_formulas_part {
     public $vars1;
     public $vars2;
     public $answer;
+    public $answernotunique;
     public $correctness;
     public $unitpenalty;
     public $postunit;

--- a/questiontype.php
+++ b/questiontype.php
@@ -57,7 +57,7 @@ class qtype_formulas extends question_type {
      * @return array.
      */
     public function part_tags() {
-        return array('placeholder', 'answermark', 'answertype', 'numbox', 'vars1', 'answer', 'vars2', 'correctness'
+        return array('placeholder', 'answermark', 'answertype', 'numbox', 'vars1', 'answer', 'answernotunique', 'vars2', 'correctness'
             , 'unitpenalty', 'postunit', 'ruleid', 'otherrule');
     }
 
@@ -242,6 +242,7 @@ class qtype_formulas extends question_type {
                     $answer->answermark = 1;
                     $answer->numbox = 1;
                     $answer->answer = '';
+                    $answer->answernotunique = 1;
                     $answer->correctness = '';
                     $answer->ruleid = 1;
                     $answer->trialmarkseq = '';
@@ -512,12 +513,22 @@ class qtype_formulas extends question_type {
                 $fromform->partindex[$anscount] = $partindex;
             }
             foreach ($tags as $tag) {
+                // Older questions do not have this field, so we do not want to issue an error message.
+                // Also, for maximum backwards compatibility, we set the default value to 1. With this,
+                // nothing changes for old questions.
+                if ($tag === 'answernotunique') {
+                    $ifnotexists = '';
+                    $default = '1';
+                } else {
+                    $ifnotexists = 'error';
+                    $default = '0';
+                }
                 $fromform->{$tag}[$anscount] = $format->getpath(
                   $answer,
                   array('#', $tag, 0 , '#' , 'text' , 0 , '#'),
-                  '0',
+                  $default,
                   false,
-                  'error'
+                  $ifnotexists
                 );
             }
 

--- a/questiontype.php
+++ b/questiontype.php
@@ -825,7 +825,7 @@ class qtype_formulas extends question_type {
                 'tags', 'oldparent', 'context', '_qf__qtype_formulas_edit_form', 'numdataset', 'multiplier', 'import_process',
                 'inpopup', 'cmid', 'courseid', 'returnurl', 'scrollpos', 'appendqnumstring', 'usecase', 'export_process',
                 'makecopy', 'submitbutton', 'status', 'shownumcorrect', 'correctness_simple_mode', 'mdlscrollto', 'image',
-                'coursetags'];
+                'coursetags', 'answernotunique'];
         foreach ($form as $key => $value) {
             if (in_array($key, $keystoskip)) {
                 continue;

--- a/renderer.php
+++ b/renderer.php
@@ -485,7 +485,13 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
 
         $correctanswer = $question->format_text($question->correct_response_formatted($part),
                 $part->subqtextformat , $qa, 'qtype_formulas', 'answersubqtext', $part->id, false);
-        return html_writer::nonempty_tag('div', get_string('correctansweris', 'qtype_formulas', $correctanswer),
+
+        if ($part->answernotunique) {
+            $string = 'correctansweris';
+        } else {
+            $string = 'uniquecorrectansweris';
+        }
+        return html_writer::nonempty_tag('div', get_string($string, 'qtype_formulas', $correctanswer),
                     array('class' => 'formulaspartcorrectanswer'));
     }
 

--- a/tests/behat/answernotunique.feature
+++ b/tests/behat/answernotunique.feature
@@ -34,10 +34,11 @@ Feature: Test different feedback for questions with unique / non-unique answer
   @javascript
   Scenario: Question with one correct answers
     When I am on the "formulas-001" "core_question > edit" page logged in as teacher1
+    And I set the field "Question name" to "Edited formulas-001"
     And I follow "Part 1"
     And I click on "There are other correct answers." "checkbox"
     And I press "id_submitbutton"
-    And I am on the "formulas-001" "core_question > preview" page logged in as teacher1
+    And I am on the "Edited formulas-001" "core_question > preview" page logged in as teacher1
     And I set the following fields to these values:
       | behaviour | immediatefeedback |
     And I press "id_saverestart"

--- a/tests/behat/answernotunique.feature
+++ b/tests/behat/answernotunique.feature
@@ -1,0 +1,46 @@
+@qtype @qtype_formulas
+Feature: Test different feedback for questions with unique / non-unique answer
+
+  Background:
+    Given the following "users" exist:
+      | username |
+      | teacher1 |
+    And the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1        | 0        |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+    And the following "question categories" exist:
+      | contextlevel | reference | name           |
+      | Course       | C1        | Test questions |
+    And the following "questions" exist:
+      | questioncategory | qtype    | name         | template      |
+      | Test questions   | formulas | formulas-001 | testsinglenum |
+    And I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I navigate to "Question bank" in current page administration
+
+  @javascript
+  Scenario: Question with multiple correct answers
+    When I am on the "formulas-001" "core_question > preview" page logged in as teacher1
+    And I set the following fields to these values:
+      | behaviour | immediatefeedback |
+    And I press "id_saverestart"
+    And I set the field "Answer" to "1"
+    And I press "Check"
+    Then I should see "One possible correct answer is"
+
+  @javascript
+  Scenario: Question with one correct answers
+    When I am on the "formulas-001" "core_question > edit" page logged in as teacher1
+    And I follow "Part 1"
+    And I click on "There are other correct answers." "checkbox"
+    And I press "id_submitbutton"
+    And I am on the "formulas-001" "core_question > preview" page logged in as teacher1
+    And I set the following fields to these values:
+      | behaviour | immediatefeedback |
+    And I press "id_saverestart"
+    And I set the field "Answer" to "1"
+    And I press "Check"
+    Then I should see "The correct answer is"

--- a/tests/behat/export.feature
+++ b/tests/behat/export.feature
@@ -1,8 +1,8 @@
 @qtype @qtype_formulas
 Feature: Test exporting Formulas questions
-  As a teacher
-  In order to be able to reuse my Formulas questions
-  I need to export them
+    As a teacher
+    In order to be able to reuse my Formulas questions
+    I need to export them
 
   Background:
     Given the following "users" exist:
@@ -18,8 +18,8 @@ Feature: Test exporting Formulas questions
       | contextlevel | reference | name           |
       | Course       | C1        | Test questions |
     And the following "questions" exist:
-      | questioncategory | qtype       | name           | template           |
-      | Test questions   | formulas    | formulas-001   | testmethodsinparts |
+      | questioncategory | qtype    | name         | template           |
+      | Test questions   | formulas | formulas-001 | testmethodsinparts |
     And I log in as "teacher1"
     And I am on "Course 1" course homepage
 
@@ -28,7 +28,7 @@ Feature: Test exporting Formulas questions
     When I am on the "Course 1" "core_question > course question export" page
     And I set the field "id_format_xml" to "1"
     And I press "Export questions to file"
-    Then following "click here" should download between "5100" and "5300" bytes
+    Then following "click here" should download between "5400" and "5600" bytes
     # If the download step is the last in the scenario then we can sometimes run
     # into the situation where the download page causes a http redirect but behat
     # has already conducted its reset (generating an error). By putting a logout

--- a/tests/helper.php
+++ b/tests/helper.php
@@ -515,7 +515,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $form->answernumbering = 'abc';
         $form->noanswers = 3;
         $form->answer = array('5', '6', '7');
-        $form->answer = array('1', '1', '1');
+        $form->answernotunique = array('1', '1', '1');
         $form->answermark = array('2', '2', '2');
         $form->numbox = array(1, 1, 1);
         $form->placeholder = array('#1', '#2', '#3');

--- a/tests/helper.php
+++ b/tests/helper.php
@@ -91,6 +91,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p->vars1 = '';
         $p->vars2 = '';
         $p->answer = '1';
+        $p->answernotunique = '1';
         $p->correctness = '_relerr < 0.01';
         $p->unitpenalty = 1;
         $p->postunit = '';
@@ -130,6 +131,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p->placeholder = '';
         $p->answermark = 2;
         $p->answer = '5';
+        $p->answernotunique = '1';
         $p->subqtext = '';
         $p->partcorrectfb = 'Your answer is correct.';
         $p->partpartiallycorrectfb = 'Your answer is partially correct.';
@@ -148,6 +150,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $form->name = 'test-0';
         $form->noanswers = 1;
         $form->answer = array('5');
+        $form->answernotunique = array('1');
         $form->answermark = array(2);
         $form->answertype = array(0);
         $form->correctness = array('_relerr < 0.01');
@@ -210,6 +213,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p->placeholder = '';
         $p->answermark = 2;
         $p->answer = '5';
+        $p->answernotunique = '1';
         $p->postunit = 'm/s';
         $p->subqtext = '{_0}{_u}';
         $p->partcorrectfb = 'Your answer is correct.';
@@ -229,6 +233,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $form->name = 'test-0';
         $form->noanswers = 1;
         $form->answer = array('5');
+        $form->answernotunique = array('1');
         $form->answermark = array(2);
         $form->answertype = array(0);
         $form->correctness = array('_relerr < 0.01');
@@ -291,6 +296,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p->placeholder = '';
         $p->answermark = 2;
         $p->answer = '5';
+        $p->answernotunique = '1';
         $p->postunit = 'm/s';
         $p->subqtext = '{_0} {_u}';
         $p->partcorrectfb = 'Your answer is correct.';
@@ -310,6 +316,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $form->name = 'test-0';
         $form->noanswers = 1;
         $form->answer = array('5');
+        $form->answernotunique = array('1');
         $form->answermark = array(2);
         $form->answertype = array(0);
         $form->correctness = array('_relerr < 0.01');
@@ -372,6 +379,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p->placeholder = '';
         $p->answermark = 2;
         $p->answer = '[2, 3]';
+        $p->answernotunique = '1';
         $p->subqtext = '';
         $p->partcorrectfb = 'Your answer is correct.';
         $p->partpartiallycorrectfb = 'Your answer is partially correct.';
@@ -390,6 +398,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $form->name = 'test-1';
         $form->noanswers = 1;
         $form->answer = array('[2, 3]');
+        $form->answernotunique = array('1');
         $form->answermark = array(2);
         $form->answertype = array(0);
         $form->correctness = array('_relerr < 0.01');
@@ -454,6 +463,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p0->id = 14;
         $p0->answermark = 2;
         $p0->answer = '5';
+        $p0->answernotunique = '1';
         $p0->subqtext = 'This is first part.';
         $p0->partcorrectfb = 'Part 1 correct feedback.';
         $p0->partpartiallycorrectfb = 'Part 1 partially correct feedback.';
@@ -465,6 +475,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p1->partindex = 1;
         $p1->answermark = 2;
         $p1->answer = '6';
+        $p1->answernotunique = '1';
         $p1->subqtext = 'This is second part.';
         $p1->partcorrectfb = 'Part 2 correct feedback.';
         $p1->partpartiallycorrectfb = 'Part 2 partially correct feedback.';
@@ -476,6 +487,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p2->partindex = 2;
         $p2->answermark = 2;
         $p2->answer = '7';
+        $p2->answernotunique = '1';
         $p2->subqtext = 'This is third part.';
         $p2->partcorrectfb = 'Part 3 correct feedback.';
         $p2->partpartiallycorrectfb = 'Part 3 partially correct feedback.';
@@ -503,6 +515,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $form->answernumbering = 'abc';
         $form->noanswers = 3;
         $form->answer = array('5', '6', '7');
+        $form->answer = array('1', '1', '1');
         $form->answermark = array('2', '2', '2');
         $form->numbox = array(1, 1, 1);
         $form->placeholder = array('#1', '#2', '#3');
@@ -581,6 +594,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p0->answermark = 2;
         $p0->subqtext = '<p>If a car travels {s} m in {dt} s, what is the speed of the car? {_0}{_u}</p>';      // Combined unit.
         $p0->answer = 'v';
+        $p0->answernotunique = '1';
         $p0->postunit = 'm/s';
         $q->parts[0] = $p0;
         $p1 = self::make_a_formulas_part();
@@ -589,6 +603,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p1->answermark = 2;
         $p1->subqtext = '<p>If a car travels {s} m in {dt} s, what is the speed of the car? {_0} {_u}</p>';     // Separated unit.
         $p1->answer = 'v';
+        $p1->answernotunique = '1';
         $p1->postunit = 'm/s';
         $q->parts[1] = $p1;
         $p2 = self::make_a_formulas_part();
@@ -598,6 +613,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         // As postunit is empty {_u} should be ignored.
         $p2->subqtext = '<p>If a car travels {s} m in {dt} s, what is the speed of the car? {_0} {_u}</p>';
         $p2->answer = 'v';
+        $p2->answernotunique = '1';
         $p2->postunit = '';
         $q->parts[2] = $p2;
         $p3 = self::make_a_formulas_part();
@@ -607,6 +623,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         // As postunit is empty {_u} should be ignored.
         $p3->subqtext = '<p>If a car travels {s} m in {dt} s, what is the speed of the car? speed = {_0}{_u}</p>';
         $p3->answer = 'v';
+        $p3->answernotunique = '1';
         $p3->postunit = '';
         $q->parts[3] = $p3;
 
@@ -659,6 +676,7 @@ class qtype_formulas_test_helper extends question_test_helper {
                 'vars1' => '',
                 'vars2' => '',
                 'answer' => 'v',
+                'answernotunique' => '1',
                 'correctness' => '_relerr < 0.01',
                 'unitpenalty' => 1,
                 'postunit' => 'm/s',
@@ -685,6 +703,7 @@ class qtype_formulas_test_helper extends question_test_helper {
                 'vars1' => '',
                 'vars2' => '',
                 'answer' => 'v',
+                'answernotunique' => '1',
                 'correctness' => '_relerr < 0.01',
                 'unitpenalty' => 1,
                 'postunit' => 'm/s',
@@ -711,6 +730,7 @@ class qtype_formulas_test_helper extends question_test_helper {
                 'vars1' => '',
                 'vars2' => '',
                 'answer' => 'v',
+                'answernotunique' => '1',
                 'correctness' => '_relerr < 0.01',
                 'unitpenalty' => 1,
                 'postunit' => '',
@@ -737,6 +757,7 @@ class qtype_formulas_test_helper extends question_test_helper {
                 'vars1' => '',
                 'vars2' => '',
                 'answer' => 'v',
+                'answernotunique' => '1',
                 'correctness' => '_relerr < 0.01',
                 'unitpenalty' => 1,
                 'postunit' => '',
@@ -800,6 +821,12 @@ class qtype_formulas_test_helper extends question_test_helper {
             1 => 'v',
             2 => 'v',
             3 => 'v',
+        );
+        $form->answernotunique = array(
+            0 => '1',
+            1 => '1',
+            2 => '1',
+            3 => '1',
         );
         $form->answermark = array(
             0 => 2,
@@ -943,6 +970,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p->id = 17;
         $p->answermark = 2;
         $p->answer = '0';
+        $p->answernotunique = '1';
         $q->parts[0] = $p;
 
         return $q;
@@ -958,6 +986,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $form->name = 'test-3';
         $form->noanswers = 1;
         $form->answer = array('0');
+        $form->answernotunique = array('1');
         $form->answermark = array(2);
         $form->answertype = array(0);
         $form->correctness = array('_relerr < 0.01');
@@ -1027,6 +1056,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p0->answermark = 2;
         $p0->subqtext = '<p>If a car travels {s} m in {dt} s, what is the speed of the car? {_0}{_u}</p>';      // Combined unit.
         $p0->answer = 'v';
+        $p0->answernotunique = '1';
         $p0->postunit = 'm/s';
         $q->parts[0] = $p0;
         $p1 = self::make_a_formulas_part();
@@ -1035,12 +1065,14 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p1->answermark = 2;
         $p1->subqtext = '<p>If a car travels {s} m in {dt} s, what is the speed of the car? {_0} {_u}</p>';     // Separated unit.
         $p1->answer = 'v';
+        $p1->answernotunique = '1';
         $p1->postunit = 'm/s';
         $q->parts[1] = $p1;
         $p2 = self::make_a_formulas_part();
         $p2->id = 20;
         $p2->partindex = 2;
         $p2->answermark = 2;
+        $p2->answernotunique = '1';
         // As postunit is empty {_u} should be ignored.
         $p2->subqtext = '<p>If a car travels {s} m in {dt} s, what is the speed of the car? {_0} {_u}</p>';
         $p2->answer = 'v';
@@ -1053,6 +1085,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         // As postunit is empty {_u} should be ignored.
         $p3->subqtext = '<p>If a car travels {s} m in {dt} s, what is the speed of the car? speed = {_0}{_u}</p>';
         $p3->answer = 'v';
+        $p3->answernotunique = '1';
         $p3->postunit = '';
         $q->parts[3] = $p3;
 
@@ -1077,6 +1110,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $form->answernumbering = 'abc';
         $form->noanswers = 4;
         $form->answer = array('v', 'v', 'v', 'v');
+        $form->answernotunique = array('1', '1', '1', '1');
         $form->answermark = array('2', '2', '2', '2');
         $form->numbox = array(1, 1, 1, 1);
         $form->placeholder = array('', '', '', '');
@@ -1164,6 +1198,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p->id = 14;
         $p->answermark = 1;
         $p->answer = '1';
+        $p->answernotunique = '1';
         $p->subqtext = '{_0:mychoices:MC}';
         $q->parts[0] = $p;
 
@@ -1180,6 +1215,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $form->name = 'test-5';
         $form->noanswers = 1;
         $form->answer = array('1');
+        $form->answernotunique = array('1');
         $form->answermark = array(1);
         $form->answertype = array(0);
         $form->correctness = array('_relerr < 0.01');
@@ -1242,6 +1278,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p->id = 14;
         $p->answermark = 1;
         $p->answer = '1';
+        $p->answernotunique = '1';
         $p->subqtext = '{_0:mychoices:MCE}';
         $q->parts[0] = $p;
 
@@ -1258,6 +1295,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $form->name = 'test-5';
         $form->noanswers = 1;
         $form->answer = array('1');
+        $form->answernotunique = array('1');
         $form->answermark = array(1);
         $form->answertype = array(0);
         $form->correctness = array('_relerr < 0.01');
@@ -1323,12 +1361,14 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p1->id = 14;
         $p1->answermark = 1;
         $p1->answer = '1';
+        $p1->answernotunique = '1';
         $p1->subqtext = '{_0:choices1:MCE}';
         $q->parts[0] = $p1;
         $p2 = self::make_a_formulas_part();
         $p2->id = 15;
         $p2->answermark = 1;
         $p2->answer = '1';
+        $p2->answernotunique = '1';
         $p2->subqtext = '{_0:choices2:MCE}';
         $q->parts[1] = $p2;
 
@@ -1345,6 +1385,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $form->name = 'testmcetwoparts';
         $form->noanswers = 2;
         $form->answer = array('1', '1');
+        $form->answernotunique = array('1', '1');
         $form->answermark = array(1, 1);
         $form->answertype = array(0, 0);
         $form->correctness = array('_relerr < 0.01', '_relerr < 0.01');
@@ -1416,12 +1457,14 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p1->id = 14;
         $p1->answermark = 1;
         $p1->answer = '1';
+        $p1->answernotunique = '1';
         $p1->subqtext = 'Part 1 -- {_0:choices1:MCE}';
         $q->parts[0] = $p1;
         $p2 = self::make_a_formulas_part();
         $p2->id = 15;
         $p2->answermark = 1;
         $p2->answer = '1';
+        $p2->answernotunique = '1';
         $p2->subqtext = 'Part 2 -- {_0:choices2:MCE}';
         $q->parts[1] = $p2;
 
@@ -1438,6 +1481,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $form->name = 'testmcetwoparts';
         $form->noanswers = 2;
         $form->answer = array('1', '1');
+        $form->answernotunique = array('1', '1');
         $form->answermark = array(1, 1);
         $form->answertype = array(0, 0);
         $form->correctness = array('_relerr < 0.01', '_relerr < 0.01');
@@ -1508,12 +1552,14 @@ class qtype_formulas_test_helper extends question_test_helper {
         $p1->id = 14;
         $p1->answermark = 1;
         $p1->answer = ['1', '2'];
+        $p1->answernotunique = '1';
         $p1->subqtext = 'Part 1 -- {_0} -- {_1}';
         $q->parts[0] = $p1;
         $p2 = self::make_a_formulas_part();
         $p2->id = 15;
         $p2->answermark = 1;
         $p2->answer = ['3', '4'];
+        $p2->answernotunique = '1';
         $p2->subqtext = 'Part 2 -- {_0} -- {_1}';
         $q->parts[1] = $p2;
 
@@ -1530,6 +1576,7 @@ class qtype_formulas_test_helper extends question_test_helper {
         $form->name = 'testtwoandtwo';
         $form->noanswers = 4;
         $form->answer = array(0 => '[1, 2]', 1 => '[3, 4]');
+        $form->answernotunique = array('1', '1');
         $form->answermark = array(0 => 1, 1 => 1);
         $form->answertype = array(0, 0);
         $form->correctness = array('_relerr < 0.01', '_relerr < 0.01');

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_formulas';
-$plugin->version = 2023080900;
+$plugin->version = 2023081200;
 
 $plugin->cron = 0;
 $plugin->requires = 2017111300;
@@ -35,6 +35,6 @@ $plugin->dependencies = array(
     'qtype_multichoice' => 2015111600,
 );
 $plugin->supported = [39, 402];
-$plugin->release = '5.2.2 for Moodle 3.9+';
+$plugin->release = '5.2.2+ for Moodle 3.9+';
 
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_formulas';
-$plugin->version = 2023081200;
+$plugin->version = 2023100800;
 
 $plugin->cron = 0;
 $plugin->requires = 2017111300;
@@ -34,7 +34,7 @@ $plugin->dependencies = array(
     'qbehaviour_adaptivemultipart' => 2014092500,
     'qtype_multichoice' => 2015111600,
 );
-$plugin->supported = [39, 402];
-$plugin->release = '5.2.2+ for Moodle 3.9+';
+$plugin->supported = [39, 403];
+$plugin->release = '5.3.0-pre for Moodle 3.9+';
 
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
As discussed in #95, this will add an option to the edit form:
![](https://github.com/FormulasQuestion/moodle-qtype_formulas/assets/52650214/d440d0ae-8b0e-459b-a82a-96b7fe098249)

Now, the teacher can define (for each part) whether there are multiple answers or not. Depending on the setting, the student will see "One possible correct answer is:" or "The correct answer is:" when reviewing their question attempt.

For old questions, the default will remain as it was, i. e. the more general text is used.