### PR TITLE
remove unnecessary tags from behat tests

### DIFF
--- a/tests/behat/answernotunique.feature
+++ b/tests/behat/answernotunique.feature
@@ -1,4 +1,4 @@
-@qtype @qtype_formulas
+@qtype @qtype_formulas @javascript
 Feature: Test different feedback for questions with unique / non-unique answer
 
   Background:
@@ -21,7 +21,6 @@ Feature: Test different feedback for questions with unique / non-unique answer
     And I am on "Course 1" course homepage
     And I navigate to "Question bank" in current page administration
 
-  @javascript
   Scenario: Question with multiple correct answers
     When I am on the "formulas-001" "core_question > preview" page logged in as teacher1
     And I set the following fields to these values:
@@ -31,7 +30,6 @@ Feature: Test different feedback for questions with unique / non-unique answer
     And I press "Check"
     Then I should see "One possible correct answer is"
 
-  @javascript
   Scenario: Question with one correct answers
     When I am on the "formulas-001" "core_question > edit" page logged in as teacher1
     And I set the field "Question name" to "Edited formulas-001"

--- a/tests/behat/backup_and_restore.feature
+++ b/tests/behat/backup_and_restore.feature
@@ -1,8 +1,8 @@
-@qtype @qtype_formulas
+@qtype @qtype_formulas @javascript
 Feature: Test duplicating a quiz containing a Formulas question
-  As a teacher
-  In order re-use my courses containing formulas questions
-  I need to be able to backup and restore them
+    As a teacher
+    In order re-use my courses containing formulas questions
+    I need to be able to backup and restore them
 
   Background:
     And the following "courses" exist:
@@ -12,17 +12,16 @@ Feature: Test duplicating a quiz containing a Formulas question
       | contextlevel | reference | name           |
       | Course       | C1        | Test questions |
     And the following "questions" exist:
-      | questioncategory | qtype       | name             | template     |
-      | Test questions   | formulas     | formulas-001    | test4        |
+      | questioncategory | qtype    | name         | template |
+      | Test questions   | formulas | formulas-001 | test4    |
     And the following "activities" exist:
-      | activity   | name      | course | idnumber |
-      | quiz       | Test quiz | C1     | quiz1    |
+      | activity | name      | course | idnumber |
+      | quiz     | Test quiz | C1     | quiz1    |
     And quiz "Test quiz" contains the following questions:
       | formulas-001 | 1 |
     And I log in as "admin"
     And I am on "Course 1" course homepage
 
-  @javascript
   Scenario: Backup and restore a course containing an formulas question
     When I backup "Course 1" course using this options:
       | Confirmation | Filename | test_backup.mbz |
@@ -31,19 +30,19 @@ Feature: Test duplicating a quiz containing a Formulas question
     And I navigate to "Question bank" in current page administration
     And I choose "Edit question" action for "formulas-001" in the question bank
     Then the following fields match these values:
-      | Question name        | formulas-001                                                                  |
-      | Question text        | This question shows different display methods of the answer and unit box.     |
-      | Random variables     | v = {20:100:10}; dt = {2:6};                                                  |
-      | Global variables     | s = v*dt;                                                                     |
-      | id_answer_0          | v                                                                             |
-      | id_answermark_0      | 2                                                                             |
-      | id_postunit_0        | m/s                                                                           |
-      | id_answer_1          | v                                                                             |
-      | id_answermark_1      | 2                                                                             |
-      | id_postunit_1        | m/s                                                                           |
-      | id_answer_2          | v                                                                             |
-      | id_answermark_2      | 2                                                                             |
-      | id_postunit_2        |                                                                               |
-      | id_answer_3          | v                                                                             |
-      | id_answermark_3      | 2                                                                             |
-      | id_postunit_3        |                                                                               |
+      | Question name    | formulas-001                                                              |
+      | Question text    | This question shows different display methods of the answer and unit box. |
+      | Random variables | v = {20:100:10}; dt = {2:6};                                              |
+      | Global variables | s = v*dt;                                                                 |
+      | id_answer_0      | v                                                                         |
+      | id_answermark_0  | 2                                                                         |
+      | id_postunit_0    | m/s                                                                       |
+      | id_answer_1      | v                                                                         |
+      | id_answermark_1  | 2                                                                         |
+      | id_postunit_1    | m/s                                                                       |
+      | id_answer_2      | v                                                                         |
+      | id_answermark_2  | 2                                                                         |
+      | id_postunit_2    |                                                                           |
+      | id_answer_3      | v                                                                         |
+      | id_answermark_3  | 2                                                                         |
+      | id_postunit_3    |                                                                           |

--- a/tests/behat/criterion.feature
+++ b/tests/behat/criterion.feature
@@ -1,4 +1,4 @@
-@qtype @qtype_formulas
+@qtype @qtype_formulas @javascript
 Feature: Test setting the grading criterion in different modes
 
   Background:
@@ -22,7 +22,6 @@ Feature: Test setting the grading criterion in different modes
     And I navigate to "Question bank" in current page administration
     And I am on the "test" "core_question > edit" page logged in as teacher1
 
-  @javascript
   Scenario: Set a simple grading criterion
     When I follow "Part 1"
     Then the following fields match these values:
@@ -44,7 +43,6 @@ Feature: Test setting the grading criterion in different modes
       | correctness_simple_comp[0] | ==             |
       | correctness_simple_tol[0]  | 0.02           |
 
-  @javascript
   Scenario: Set an expert grading criterion
     When I follow "Part 1"
     And I click on "Simplified mode" "checkbox"
@@ -75,7 +73,6 @@ Feature: Test setting the grading criterion in different modes
       | correctness[0] | _err == 0 && 1 == 1 |
     And the "Simplified mode" "checkbox" should be disabled
 
-  @javascript
   Scenario: Switch from easy to expert
     When I follow "Part 1"
     And I click on "Simplified mode" "checkbox"
@@ -93,7 +90,6 @@ Feature: Test setting the grading criterion in different modes
     Then the following fields match these values:
       | correctness[0] | _err == 0 |
 
-  @javascript
   Scenario: Switch from expert to easy
     When I follow "Part 1"
     And I click on "Simplified mode" "checkbox"

--- a/tests/behat/edit.feature
+++ b/tests/behat/edit.feature
@@ -24,7 +24,6 @@ Feature: Test editing a Formulas question
     And I am on "Course 1" course homepage
     And I navigate to "Question bank" in current page administration
 
-  @javascript @_switch_window
   Scenario: Edit a Formulas question
     When I am on the "formulas-001 for editing" "core_question > edit" page logged in as teacher1
     And I set the field "Question name" to ""

--- a/tests/behat/editquickvalidation.feature
+++ b/tests/behat/editquickvalidation.feature
@@ -1,4 +1,4 @@
-@qtype @qtype_formulas
+@qtype @qtype_formulas @javascript
 Feature: Test on-the-fly validation of variables while editing a question
 
   Background:
@@ -22,7 +22,6 @@ Feature: Test on-the-fly validation of variables while editing a question
     And I navigate to "Question bank" in current page administration
     And I am on the "test" "core_question > edit" page logged in as teacher1
 
-  @javascript
   Scenario: Validate random variables
     When I follow "Variables"
     And I set the field "Random variables" to "a=+"
@@ -32,7 +31,6 @@ Feature: Test on-the-fly validation of variables while editing a question
     And I take focus off "id_varsrandom" "field"
     Then I should not see "1: a: Syntax error."
 
-  @javascript
   Scenario: Validate global variables
     When I follow "Variables"
     And I set the field "Global variables" to "a=+"
@@ -51,7 +49,6 @@ Feature: Test on-the-fly validation of variables while editing a question
     And I take focus off "id_varsglobal" "field"
     Then I should not see "1: Variable 'b' has not been defined. in substitute_vname_by_variables"
 
-  @javascript
   Scenario: Validate global variables with prior error in random variables
     When I follow "Variables"
     And I set the following fields to these values:
@@ -61,7 +58,6 @@ Feature: Test on-the-fly validation of variables while editing a question
     Then I should see "1: a: Syntax error." in the "#id_error_varsrandom" "css_element"
     And the focused element is "id_varsrandom" "field"
 
-  @javascript
   Scenario: Validate local variables
     When I follow "Part 1"
     And I follow "Show more..."
@@ -89,7 +85,6 @@ Feature: Test on-the-fly validation of variables while editing a question
     And I take focus off "id_vars1_0" "field"
     Then I should not see "1: Variable 'c' has not been defined. in substitute_vname_by_variables"
 
-  @javascript
   Scenario: Validate local variables with prior error in random or global variables
     When I follow "Variables"
     And I set the following fields to these values:

--- a/tests/behat/export.feature
+++ b/tests/behat/export.feature
@@ -1,4 +1,4 @@
-@qtype @qtype_formulas
+@qtype @qtype_formulas @javascript @_file_upload
 Feature: Test exporting Formulas questions
     As a teacher
     In order to be able to reuse my Formulas questions
@@ -23,7 +23,6 @@ Feature: Test exporting Formulas questions
     And I log in as "teacher1"
     And I am on "Course 1" course homepage
 
-  @javascript @_file_upload
   Scenario: Export a Formulas question
     When I am on the "Course 1" "core_question > course question export" page
     And I set the field "id_format_xml" to "1"

--- a/tests/behat/import.feature
+++ b/tests/behat/import.feature
@@ -1,8 +1,8 @@
-@qtype @qtype_formulas
+@qtype @qtype_formulas @javascript @_file_upload
 Feature: Test importing Formulas questions
-  As a teacher
-  In order to reuse my Formulas questions
-  I need to import them
+    As a teacher
+    In order to reuse my Formulas questions
+    I need to import them
 
   Background:
     Given the following "users" exist:
@@ -17,7 +17,6 @@ Feature: Test importing Formulas questions
     And I log in as "teacher1"
     And I am on "Course 1" course homepage
 
-  @javascript @_file_upload
   Scenario: import formulas question.
     When I am on the "Course 1" "core_question > course question import" page
     And I set the field "id_format_xml" to "1"

--- a/tests/behat/instantiation.feature
+++ b/tests/behat/instantiation.feature
@@ -1,4 +1,4 @@
-@qtype @qtype_formulas
+@qtype @qtype_formulas @javascript
 Feature: Test instantiation and inline preview while editing a question
 
   Background:
@@ -22,7 +22,6 @@ Feature: Test instantiation and inline preview while editing a question
     And I navigate to "Question bank" in current page administration
     And I am on the "test" "core_question > edit" page logged in as teacher1
 
-  @javascript
   Scenario: Instantiate and preview
     When I set the following fields to these values:
       | id_varsglobal   | a=3;                          |
@@ -41,7 +40,6 @@ Feature: Test instantiation and inline preview while editing a question
     When I click on row number "2" of the Formulas Question instantiation table
     Then I should not see "Part 1" in the "#qtextpreview_display" "css_element"
 
-  @javascript
   Scenario: Try to instantiate with invalid data
     When I set the following fields to these values:
       | id_varsglobal   | a=x+;                         |

--- a/tests/behat/mobile.feature
+++ b/tests/behat/mobile.feature
@@ -72,7 +72,6 @@ Feature: Mobile compatibility
     And I log in as "student"
     And I entered the course "Course 1" in the app
 
-  @app @javascript
   Scenario: Try to answer a question with one part and one answer field
     When I press "Quiz 1" in the app
     And I press "Attempt quiz now" in the app
@@ -82,7 +81,6 @@ Feature: Mobile compatibility
     And I press "OK" near "Once you submit" in the app
     Then I should find "Your answer is correct." in the app
 
-  @app @javascript
   Scenario: Try to answer a question with one part and two answer fields
     When I press "Quiz 2" in the app
     And I press "Attempt quiz now" in the app
@@ -93,7 +91,6 @@ Feature: Mobile compatibility
     And I press "OK" near "Once you submit" in the app
     Then I should find "Your answer is correct." in the app
 
-  @app @javascript
   Scenario: Try to answer a question with one combined answer+unit field
     When I press "Quiz 3" in the app
     And I press "Attempt quiz now" in the app
@@ -103,7 +100,6 @@ Feature: Mobile compatibility
     And I press "OK" near "Once you submit" in the app
     Then I should find "Your answer is correct." in the app
 
-  @app @javascript
   Scenario: Try to answer a question with one answer + one unit field
     When I press "Quiz 4" in the app
     And I press "Attempt quiz now" in the app
@@ -114,7 +110,6 @@ Feature: Mobile compatibility
     And I press "OK" near "Once you submit" in the app
     Then I should find "Your answer is correct." in the app
 
-  @app @javascript
   Scenario: Try to answer a question with three parts and one answer field each
     When I press "Quiz 5" in the app
     And I press "Attempt quiz now" in the app
@@ -128,7 +123,6 @@ Feature: Mobile compatibility
     And I should find "Part 2 correct feedback." in the app
     And I should find "Part 3 correct feedback." in the app
 
-  @app @javascript
   Scenario: Try to answer a radiobutton multiple choice formula question
     When I press "Quiz 6" in the app
     And I press "Attempt quiz now" in the app
@@ -138,7 +132,6 @@ Feature: Mobile compatibility
     And I press "OK" near "Once you submit" in the app
     Then I should find "Your answer is correct." in the app
 
-  @app @javascript
   Scenario: Try to answer a drowdown multiple choice formula question
     When I press "Quiz 7" in the app
     And I press "Attempt quiz now" in the app
@@ -149,7 +142,6 @@ Feature: Mobile compatibility
     And I press "OK" near "Once you submit" in the app
     Then I should find "Your answer is correct." in the app
 
-  @app @javascript
   Scenario: Try to answer a question with two parts, one drowdown multiple choice in each of them
     When I press "Quiz 8" in the app
     And I press "Attempt quiz now" in the app
@@ -161,7 +153,6 @@ Feature: Mobile compatibility
     Then I should find "Your first answer is correct." in the app
     And I should find "Your second answer is correct." in the app
 
-  @app @javascript
   Scenario: Try to answer a question with two parts, one radio multiple choice in each of them
     When I press "Quiz 9" in the app
     And I press "Attempt quiz now" in the app
@@ -173,7 +164,6 @@ Feature: Mobile compatibility
     Then I should find "Your first answer is correct." in the app
     And I should find "Your second answer is correct." in the app
 
-  @app @javascript
   Scenario: Try to answer a question with two parts, two numbers in each of them
     When I press "Quiz 10" in the app
     And I press "Attempt quiz now" in the app

--- a/tests/behat/preview.feature
+++ b/tests/behat/preview.feature
@@ -27,7 +27,6 @@ Feature: Preview a Formulas question
       | question     | page |
       | formulas-001 | 1    |
 
-  @javascript @_switch_window
   Scenario: Preview a formulas question with correct answer
     When I am on the "formulas-001" "core_question > preview" page logged in as teacher1
     Then I should see "This question shows different display methods of the answer and unit box."
@@ -45,7 +44,6 @@ Feature: Preview a Formulas question
     And I should see "This is the general feedback."
     And I should see "One possible correct answer is: 40 m/s"
 
-  @javascript @_switch_window
   Scenario: Preview an formulas question with incorrect answer
     When I am on the "formulas-001" "core_question > preview" page logged in as teacher1
     Then I should see "This question shows different display methods of the answer and unit box."

--- a/tests/behat/quiz.feature
+++ b/tests/behat/quiz.feature
@@ -71,7 +71,6 @@ Feature: Usage in quiz
     And I log in as "student"
     And I am on "Course 1" course homepage
 
-  @javascript
   Scenario: Try to answer a question with one part and one answer field
     When I follow "Quiz 1"
     And I press "Attempt quiz"
@@ -83,7 +82,6 @@ Feature: Usage in quiz
     And I confirm the quiz submission in the modal dialog
     Then I should see "Your answer is correct."
 
-  @javascript
   Scenario: Try to answer a question with one part and two answer fields
     When I follow "Quiz 2"
     And I press "Attempt quiz"
@@ -94,7 +92,6 @@ Feature: Usage in quiz
     And I confirm the quiz submission in the modal dialog
     Then I should see "Your answer is correct."
 
-  @javascript
   Scenario: Try to answer a question with one combined answer+unit field
     When I follow "Quiz 3"
     And I press "Attempt quiz"
@@ -104,7 +101,6 @@ Feature: Usage in quiz
     And I confirm the quiz submission in the modal dialog
     Then I should see "Your answer is correct."
 
-  @javascript
   Scenario: Try to answer a question with one answer + one unit field
     When I follow "Quiz 4"
     And I press "Attempt quiz"
@@ -115,7 +111,6 @@ Feature: Usage in quiz
     And I confirm the quiz submission in the modal dialog
     Then I should see "Your answer is correct."
 
-  @javascript
   Scenario: Try to answer a question with three parts and one answer field each
     When I follow "Quiz 5"
     And I press "Attempt quiz"
@@ -129,7 +124,6 @@ Feature: Usage in quiz
     And I should see "Part 2 correct feedback."
     And I should see "Part 3 correct feedback."
 
-  @javascript
   Scenario: Try to answer a radiobutton multiple choice formula question
     When I follow "Quiz 6"
     And I press "Attempt quiz"
@@ -139,7 +133,6 @@ Feature: Usage in quiz
     And I confirm the quiz submission in the modal dialog
     Then I should see "Your answer is correct."
 
-  @javascript
   Scenario: Try to answer a drowdown multiple choice formula question
     When I follow "Quiz 7"
     And I press "Attempt quiz"
@@ -149,7 +142,6 @@ Feature: Usage in quiz
     And I confirm the quiz submission in the modal dialog
     Then I should see "Your answer is correct."
 
-  @javascript
   Scenario: Try to answer a question with two parts, one drowdown multiple choice in each of them
     When I follow "Quiz 8"
     And I press "Attempt quiz"
@@ -161,7 +153,6 @@ Feature: Usage in quiz
     Then I should see "Your first answer is correct."
     And I should see "Your second answer is correct."
 
-  @javascript
   Scenario: Try to answer a question with two parts, one radio multiple choice in each of them
     When I follow "Quiz 9"
     And I press "Attempt quiz"
@@ -173,7 +164,6 @@ Feature: Usage in quiz
     Then I should see "Your first answer is correct."
     And I should see "Your second answer is correct."
 
-  @javascript
   Scenario: Try to answer a question with two parts, two numbers in each of them
     When I follow "Quiz 10"
     And I press "Attempt quiz"

--- a/tests/behat/validation.feature
+++ b/tests/behat/validation.feature
@@ -4,22 +4,22 @@ Feature: Validation of input
   Background:
     Given the following "users" exist:
       | username |
-      | student |
+      | student  |
     And the following "courses" exist:
       | fullname | shortname |
       | Course 1 | C1        |
     And the following "course enrolments" exist:
-      | user     | course | role           |
-      | student  | C1     | student |
+      | user    | course | role    |
+      | student | C1     | student |
     And the following "question categories" exist:
       | contextlevel | reference | name           |
       | Course       | C1        | Test questions |
     And the following "questions" exist:
-      | questioncategory | qtype      | name         | template           |
-      | Test questions   | formulas   | formulas-001 | testmethodsinparts |
+      | questioncategory | qtype    | name         | template           |
+      | Test questions   | formulas | formulas-001 | testmethodsinparts |
     And the following "activities" exist:
-      | activity   | name   | course | idnumber |
-      | quiz       | Quiz 1 | C1     | quiz1    |
+      | activity | name   | course | idnumber |
+      | quiz     | Quiz 1 | C1     | quiz1    |
     And quiz "Quiz 1" contains the following questions:
       | question     | page |
       | formulas-001 | 1    |
@@ -27,7 +27,6 @@ Feature: Validation of input
     And I am on the "Quiz 1" "mod_quiz > View" page logged in as "student"
     And I press "Attempt quiz"
 
-  @javascript
   Scenario: Check validation of input works
     When I set the field "Answer for part 2" to "1+"
     # First make sure the script has been loaded and parsed


### PR DESCRIPTION
* Tags appearing in the feature header are automatically applied to all scenarios in the file and do not need to be repeated.
* Remove `@javascript` tag where possible in order to speed up the behat tests
* Removing `@_switch_window` tags at some places, as it should not be needed