### PR TITLE
Make question robust against fragile grading criterions

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -980,7 +980,7 @@ class qtype_formulas extends question_type {
 
             try {
                 $responses = $qo->get_correct_responses_individually($ans);
-                $correctness = $qo->grade_responses_individually($ans, $responses, $unitcheck);
+                $correctness = $qo->grade_responses_individually($ans, $responses, $unitcheck, true);
             } catch (Exception $e) {
                 $errors["correctness[$idx]"] = get_string('error_validation_eval', 'qtype_formulas') . $e->getMessage();
                 continue;

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -229,6 +229,27 @@ class question_test extends \basic_testcase {
         $this->assertEquals($expected, $partscores);
     }
 
+    public function test_with_invalidated_grading_criterion() {
+        $q = $this->get_test_formulas_question('testtwonums');
+
+        // Set the grading criterion to _0/_1 which will be invalid if the student
+        // enters 0 as their second answer.
+        $q->parts[0]->correctness = '_0/_1';
+        $q->parts[0]->numbox = 2;
+        $q->start_attempt(new question_attempt_step(), 1);
+
+        // The invalid grading criterion should not lead to an exception, but get
+        // 0 marks.
+        $response = ['0_0' => 1, '0_1' => 0];
+        $partscores = $q->grade_parts_that_can_be_graded($response, [], false);
+        $this->assertEquals(0, $partscores[0]->rawfraction);
+
+        // This time the grading criterion can be evaluated.
+        $response = ['0_0' => 1, '0_1' => 2];
+        $partscores = $q->grade_parts_that_can_be_graded($response, [], false);
+        $this->assertEquals(0.5, $partscores[0]->rawfraction);
+    }
+
     public function test_grade_parts_that_can_be_graded_test4() {
         $q = $this->get_test_formulas_question('testthreeparts');
         $q->start_attempt(new question_attempt_step(), 1);


### PR DESCRIPTION
The grading criterion is validated when the question is created or modified. It is therefore not possible to store an invalid grading criterion, i. e. one that contains undefined variables or one that would contain invalid operations like division by zero.

However, it is possible for the user to use values from the student answer in the grading criterion, e.g. they might write `_0/_1 = a/b` where `a` and `b` are valid variables. This criterion will validate, because during validation, the fields `_0` and `_1` will contain the values from the model answer.

Now, if a student enters `1` and `0` in the answer fields, the criterion will become `1/0 == a/b` and division by zero is not defined. Currently this will cause the question to fail and can even lead to an invalid attempt state being stored in the DB.

This PR modifies the legacy code in order to make sure a ~badly-written~ risky grading criterion that is invalidated by a wrong student answer cannot break the question. A unit test is added to verify this works in the future.