### PR TITLE
Test validation and robustness of grading vars

### DIFF
--- a/question.php
+++ b/question.php
@@ -708,8 +708,12 @@ class qtype_formulas_question extends question_graded_automatically_with_countba
         $this->add_special_correctness_variables($vars, $modelanswers, $coordinates, $dres->diff, $dres->is_number);
 
         // Step 7: Evaluate the grading variables and grading criteria to determine whether the answer is correct.
-        $vars = $this->qv->evaluate_assignments($vars, $part->vars2);
+        // Both steps can be in the same try-catch block, because upon validation, the grading vars
+        // are checked by another method and *before* the grading criterion. If they are invalid,
+        // the form validation stops therefore stops before validation the grading criterion and
+        // the error will not be linked to the wrong field.
         try {
+            $vars = $this->qv->evaluate_assignments($vars, $part->vars2);
             $correctness = $this->qv->evaluate_general_expression($vars, $part->correctness);
         } catch (Throwable $t) {
             // If the criterion cannot be evaluated (possible e.g. if the teacher uses part of the student's

--- a/tests/behat/edit.feature
+++ b/tests/behat/edit.feature
@@ -57,3 +57,14 @@ Feature: Test editing a Formulas question
     And I set the field "Answer for part 3" to "7"
     And I press "Check"
     And I should see "Correct"
+
+  Scenario: Check validation of grading vars
+    When I am on the "formulas-001 for editing" "core_question > edit" page logged in as teacher1
+    And I set the following fields to these values:
+      | Grading variables | test = 1/0; |
+    And I press "id_submitbutton"
+    Then I should see "Try evalution error! 1: Some expressions cannot be evaluated numerically."
+    And I set the following fields to these values:
+      | Grading variables | test = 2; |
+    And I press "id_submitbutton"
+    Then I should not see "Try evalution error! 1: Some expressions cannot be evaluated numerically."

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -229,6 +229,28 @@ class question_test extends \basic_testcase {
         $this->assertEquals($expected, $partscores);
     }
 
+    public function test_with_invalidated_grading_vars() {
+        $q = $this->get_test_formulas_question('testtwonums');
+
+        // Set the grading vars to _0/_1 which will be invalid if the student
+        // enters 0 as their second answer.
+        $q->parts[0]->vars2 = 'test = _0/_1';
+        $q->parts[0]->correctness = 'test';
+        $q->parts[0]->numbox = 2;
+        $q->start_attempt(new question_attempt_step(), 1);
+
+        // The invalid grading criterion should not lead to an exception, but get
+        // 0 marks.
+        $response = ['0_0' => 1, '0_1' => 0];
+        $partscores = $q->grade_parts_that_can_be_graded($response, [], false);
+        $this->assertEquals(0, $partscores[0]->rawfraction);
+
+        // This time the grading criterion can be evaluated.
+        $response = ['0_0' => 1, '0_1' => 2];
+        $partscores = $q->grade_parts_that_can_be_graded($response, [], false);
+        $this->assertEquals(0.5, $partscores[0]->rawfraction);
+    }
+
     public function test_with_invalidated_grading_criterion() {
         $q = $this->get_test_formulas_question('testtwonums');
 


### PR DESCRIPTION
The problem outlined in #122 shows that teachers might accidentally create risky a grading criterion. They might also do the same in the grading vars, e.g. using `testvar = _0/_1;`.

This PR adds a unit test to make sure invalidated grading vars do not break a question. Also, while fixing the issue in #122, I realized that we do not verify the validation of the grading vars in the edit form actually works. Therefore, this PR adds a behat test.