### PR TITLE
update CI: remove PHP 8.0 from test matrix for Moodle main branch

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -44,6 +44,8 @@ jobs:
             php: '7.4'
           - moodle-branch: 'master'
             php: '7.4'
+          - moodle-branch: 'master'
+            php: '8.0'
         include:
           - php: '8.2'
             moodle-branch: 'MOODLE_402_STABLE'

--- a/.github/workflows/behatmobile.yml
+++ b/.github/workflows/behatmobile.yml
@@ -43,6 +43,8 @@ jobs:
             php: '7.4'
           - moodle-branch: 'master'
             php: '7.4'
+          - moodle-branch: 'master'
+            php: '8.0'
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1', '8.2']
+        php: ['8.1', '8.2']
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,6 +45,8 @@ jobs:
             php: '7.4'
           - moodle-branch: 'master'
             php: '7.4'
+          - moodle-branch: 'master'
+            php: '8.0'
         include:
           - php: '7.4'
             moodle-branch: 'MOODLE_39_STABLE'


### PR DESCRIPTION
The next upcoming release of Moodle LMS needs at least PHP 8.1, so we can no longer test master (main) branch with PHP 8.0