### PR TITLE
add plugin name to custom behat step

### DIFF
--- a/tests/behat/behat_qtype_formulas.php
+++ b/tests/behat/behat_qtype_formulas.php
@@ -80,9 +80,9 @@ class behat_qtype_formulas extends behat_base {
     }
 
     /**
-     * @Given /^I confirm the quiz submission in the modal dialog$/
+     * @Given /^I confirm the quiz submission in the modal dialog for the formulas plugin$/
      */
-    public function i_confirm_the_quiz_submission_in_the_modal_dialog() {
+    public function i_confirm_the_quiz_submission_in_the_modal_dialog_for_the_formulas_plugin() {
         global $CFG;
         require_once($CFG->libdir . '/environmentlib.php');
         require($CFG->dirroot . '/version.php');

--- a/tests/behat/quiz.feature
+++ b/tests/behat/quiz.feature
@@ -133,7 +133,7 @@ Feature: Usage in quiz
     And I click on "Cat" "radio"
     And I press "Finish attempt"
     And I press "Submit all and finish"
-    And I confirm the quiz submission in the modal dialog
+    And I confirm the quiz submission in the modal dialog for the formulas plugin
     Then I should see "Your answer is correct."
 
   Scenario: Try to answer a drowdown multiple choice formula question
@@ -166,7 +166,7 @@ Feature: Usage in quiz
     And I click on "Blue" "radio"
     And I press "Finish attempt"
     And I press "Submit all and finish"
-    And I confirm the quiz submission in the modal dialog
+    And I confirm the quiz submission in the modal dialog for the formulas plugin
     Then I should see "Your first answer is correct."
     And I should see "Your second answer is correct."
 


### PR DESCRIPTION
The [developer docs](https://moodledev.io/general/development/tools/behat/writing#when-you-define-more-steps-in-your-plugin-make-it-clear-they-come-from-your-plugin) say:

> When you define more steps in your plugin, make it clear they come from your plugin

This PR makes sure we respect that guideline in order to avoid conflicts when tests are done on a system that has other plugins installed. (If they respect the guideline, it should not be a problem.)

This fixes #131.