### PR TITLE
PHP 8.2 compatibility: "save and continue editing" fails

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -825,7 +825,7 @@ class qtype_formulas extends question_type {
                 'tags', 'oldparent', 'context', '_qf__qtype_formulas_edit_form', 'numdataset', 'multiplier', 'import_process',
                 'inpopup', 'cmid', 'courseid', 'returnurl', 'scrollpos', 'appendqnumstring', 'usecase', 'export_process',
                 'makecopy', 'submitbutton', 'status', 'shownumcorrect', 'correctness_simple_mode', 'mdlscrollto', 'image',
-                'coursetags', 'answernotunique'];
+                'coursetags', 'answernotunique', 'updatebutton'];
         foreach ($form as $key => $value) {
             if (in_array($key, $keystoskip)) {
                 continue;


### PR DESCRIPTION
The "save and continue editing" button sets "updatebutton" when submitting the form and due to the way how the old code is organised, that will cause a failure with PHP 8.2.

This PR fixes the problem.