### PR TITLE
Fix instantiation check problem with < char

### DIFF
--- a/classes/external/instantiation.php
+++ b/classes/external/instantiation.php
@@ -154,13 +154,13 @@ class instantiation extends \external_api {
         return new \external_function_parameters(
             array(
                 'n' => new \external_value(PARAM_INT, 'number of data sets', VALUE_DEFAULT, 1),
-                'randomvars' => new \external_value(PARAM_TEXT, 'random variables', VALUE_REQUIRED),
-                'globalvars' => new \external_value(PARAM_TEXT, 'global variables', VALUE_REQUIRED),
+                'randomvars' => new \external_value(PARAM_RAW, 'random variables', VALUE_REQUIRED),
+                'globalvars' => new \external_value(PARAM_RAW, 'global variables', VALUE_REQUIRED),
                 'localvars' => new \external_multiple_structure(
-                    new \external_value(PARAM_TEXT, 'local variables, per part', VALUE_REQUIRED)
+                    new \external_value(PARAM_RAW, 'local variables, per part', VALUE_REQUIRED)
                 ),
                 'answers' => new \external_multiple_structure(
-                    new \external_value(PARAM_TEXT, 'answers, per part', VALUE_REQUIRED)
+                    new \external_value(PARAM_RAW, 'answers, per part', VALUE_REQUIRED)
                 )
             )
         );

--- a/tests/externallib_test.php
+++ b/tests/externallib_test.php
@@ -254,6 +254,31 @@ class externallib_test extends \externallib_advanced_testcase {
             array(
                 'n' => 1,
                 'randomvars' => '',
+                'globalvars' => 'a=1; b=2; c=(b<a)',
+                'localvars' => array(''),
+                'answers' => array('1'),
+                'return' => array(
+                    'status' => 'ok',
+                    'data' => array(
+                        array(
+                            'randomvars' => array(),
+                            'globalvars' => array(
+                                array('name' => 'a', 'value' => '1'),
+                                array('name' => 'b', 'value' => '2'),
+                                array('name' => 'c', 'value' => '0')
+                            ),
+                            'parts' => array(
+                                array(
+                                    array('name' => '_0', 'value' => '1'),
+                                )
+                            ),
+                        )
+                    )
+                )
+            ),
+            array(
+                'n' => 1,
+                'randomvars' => '',
                 'globalvars' => 'a=3; b=2; c=a*b',
                 'localvars' => array(''),
                 'answers' => array('a*b'),


### PR DESCRIPTION
Currently, the instantiation check in the edit form can fail if the variable definition contains the `<` char. This is, because we currently use `PARAM_TEXT` and this does not support the `<` char despite the [Moodle docs stating otherwise](https://github.com/moodle/moodle/blob/9587029a4609b3222a3564207aada02716d3332d/lib/moodlelib.php#L231-L234).

We will now use PARAM_RAW and solve that problem. The PR adds a test case to the unit test.