### PR TITLE
CI: update for upcoming moodle-plugin-ci

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.4', '8.0', '8.1']
-        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'master']
+        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'main']
         database: [mariadb]
         exclude:
           - moodle-branch: 'MOODLE_39_STABLE'
@@ -38,9 +38,9 @@ jobs:
             php: '7.4'
           - moodle-branch: 'MOODLE_403_STABLE'
             php: '7.4'
-          - moodle-branch: 'master'
+          - moodle-branch: 'main'
             php: '7.4'
-          - moodle-branch: 'master'
+          - moodle-branch: 'main'
             php: '8.0'
         include:
           - php: '8.2'
@@ -50,7 +50,7 @@ jobs:
             moodle-branch: 'MOODLE_403_STABLE'
             database: 'mariadb'
           - php: '8.2'
-            moodle-branch: 'master'
+            moodle-branch: 'main'
             database: 'mariadb'
 
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,16 +52,11 @@ jobs:
           moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
         env:
           DB: mariadb
-          MOODLE_BRANCH: 'master'
+          MOODLE_BRANCH: 'main'
 
       - name: PHP Lint
         if: ${{ always() }}
         run: moodle-plugin-ci phplint
-
-      #- name: PHP Copy/Paste Detector
-      #  continue-on-error: true
-      #  if: ${{ always() }}
-      #  run: moodle-plugin-ci phpcpd
 
       #- name: Moodle Code Checker
       #  continue-on-error: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.4', '8.0', '8.1']
-        moodle-branch: ['MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'master']
+        moodle-branch: ['MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'main']
         database: [pgsql]
         exclude:
           - moodle-branch: 'MOODLE_311_STABLE'
@@ -43,9 +43,9 @@ jobs:
             php: '7.4'
           - moodle-branch: 'MOODLE_403_STABLE'
             php: '7.4'
-          - moodle-branch: 'master'
+          - moodle-branch: 'main'
             php: '7.4'
-          - moodle-branch: 'master'
+          - moodle-branch: 'main'
             php: '8.0'
         include:
           - php: '7.4'
@@ -58,7 +58,7 @@ jobs:
             moodle-branch: 'MOODLE_403_STABLE'
             database: pgsql
           - php: '8.2'
-            moodle-branch: 'master'
+            moodle-branch: 'main'
             database: pgsql
 
     steps:
@@ -97,8 +97,3 @@ jobs:
           moodle-plugin-ci coveralls-upload
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Behat is done separately to allow app testing as well
-      #- name: Behat features
-      #  if: ${{ always() }}
-      #  run: moodle-plugin-ci behat --profile chrome


### PR DESCRIPTION
Next minor version of moodle-plugin-ci is coming soon and has some [changes](https://moodlehq.github.io/moodle-plugin-ci/CHANGELOG.html). This PR changes

* master to main when checking out from the Moodle repository
* remove PHP copy/paste detector (phpcpd) which is deprecated and will be removed in version 5

Taking the opportunity to do some cleanup (remove reference to behat from unit test workflow)
