### PR TITLE
Improve ncr() function

### DIFF
--- a/tests/functions_test.php
+++ b/tests/functions_test.php
@@ -65,7 +65,8 @@ class functions_test extends \advanced_testcase {
             array(ncr(5, 2), 10),
             array(ncr(5, 3), 10),
             array(ncr(5, 4), 5),
-            array(ncr(5, 5), 1)
+            array(ncr(5, 5), 1),
+            array(ncr(23, 3), 1771)
         );
         foreach ($testcases as $case) {
             $this->assertEquals($case[1], $case[0]);

--- a/variables.php
+++ b/variables.php
@@ -261,11 +261,13 @@ function ncr($n, $r) {
     if (($n - $r) < $r) {
         return ncr($n, ($n - $r));
     }
-    $return = 1;
-    for ($i = 0; $i < $r; $i++) {
-         $return *= ($n - $i) / ($i + 1);
+    $numerator = 1;
+    $denominator = 1;
+    for ($i = 1; $i <= $r; $i++) {
+        $numerator *= ($n - $i + 1);
+        $denominator *= $i;
     }
-    return $return;
+    return intdiv($numerator, $denominator);
 }
 
 function gcd($a, $b) {


### PR DESCRIPTION
Current implementation uses repeated division which can cause precision problems. This PR fixes the issue and makes sure the result is always an integer.