### PR TITLE
Migrate tooltips to Bootstrap

### DIFF
--- a/lang/en/qtype_formulas.php
+++ b/lang/en/qtype_formulas.php
@@ -357,6 +357,8 @@ $string['varsstatistics'] = 'Statistics';
 $string['yougotnright'] = 'You have correctly answered {$a} parts of this question.';
 $string['yougotoneright'] = 'You have correctly answered 1 part of this question.';
 
+// phpcs:disable moodle.Files.LangFilesOrdering.IncorrectOrder
+// phpcs:ignore moodle.Files.LangFilesOrdering.UnexpectedComment
 // Strings from the 5.3 branch that we keep in this file in order for them to remain in AMOS.
 $string['choiceno'] = 'No';
 $string['choiceyes'] = 'Yes';

--- a/renderer.php
+++ b/renderer.php
@@ -266,10 +266,12 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
             $inputattributes = [
                 'type' => 'text',
                 'name' => $inputname,
+                'data-toggle' => 'tooltip',
+                'data-title' => get_string($gtype . ($part->postunit == '' ? '' : '_unit'), 'qtype_formulas'),
                 'title' => get_string($gtype . ($part->postunit == '' ? '' : '_unit'), 'qtype_formulas'),
                 'value' => $currentanswer,
                 'id' => $inputname,
-                'class' => 'formulas_' . $gtype . '_unit ' . $sub->feedbackclass,
+                'class' => 'form-control formulas_' . $gtype . '_unit ' . $sub->feedbackclass,
                 'maxlength' => 128,
                 'aria-labelledby' => 'lbl_' . str_replace(':', '__', $inputname),
             ];
@@ -310,6 +312,9 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
                 'name' => $inputname,
                 'value' => $currentanswer,
                 'id' => $inputname,
+                'data-toggle' => 'tooltip',
+                'data-title' => get_string($gtype . ($part->postunit == '' ? '' : '_unit'), 'qtype_formulas'),
+                'title' => get_string($gtype . ($part->postunit == '' ? '' : '_unit'), 'qtype_formulas'),
                 'maxlength' => 128,
                 'aria-labelledby' => 'lbl_' . str_replace(':', '__', $inputname),
             ];
@@ -338,6 +343,8 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
                         $choices[$x] = $question->format_text($mctxt, $part->subqtextformat , $qa,
                                 'qtype_formulas', 'answersubqtext', $part->id, false);
                     }
+                    unset($inputattributes['data-toggle']);
+                    unset($inputattributes['data-title']);
                     $select = html_writer::select($choices, $inputname,
                             $currentanswer, ['' => ''], $inputattributes);
                     $output = html_writer::start_tag('span', ['class' => 'formulas_menu']);
@@ -386,6 +393,8 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
                             $class .= ' ' . $sub->feedbackclass;
                         }
                         $output .= $this->choice_wrapper_start($class);
+                        unset($inputattributes['data-toggle']);
+                        unset($inputattributes['data-title']);
                         $output .= html_writer::empty_tag('input', $inputattributes);
                         $output .= html_writer::tag(
                             'label',
@@ -414,7 +423,9 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
                 // Check if it's an input for unit.
                 if (strlen($part->postunit) > 0) {
                     $inputattributes['title'] = get_string('unit', 'qtype_formulas');
-                    $inputattributes['class'] = 'formulas_unit '.$sub->unitfeedbackclass;
+                    $inputattributes['class'] = 'form-control formulas_unit '.$sub->unitfeedbackclass;
+                    $inputattributes['data-title'] = get_string('unit', 'qtype_formulas');
+                    $inputattributes['data-toggle'] = 'tooltip';
                     $a = new stdClass();
                     $a->part = $i + 1;
                     $a->numanswer = $j + 1;
@@ -436,7 +447,9 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
                 }
             } else {
                 $inputattributes['title'] = get_string($gtype, 'qtype_formulas');
-                $inputattributes['class'] = 'formulas_'.$gtype.' '.$sub->boxfeedbackclass;
+                $inputattributes['class'] = 'form-control formulas_'.$gtype.' '.$sub->boxfeedbackclass;
+                $inputattributes['data-toggle'] = 'tooltip';
+                $inputattributes['data-title'] = get_string($gtype, 'qtype_formulas');
                 $inputattributes['aria-labelledby'] = 'lbl_' . str_replace(':', '__', $inputattributes['id']);
                 $a = new stdClass();
                 $a->part = $i + 1;

--- a/renderer.php
+++ b/renderer.php
@@ -96,7 +96,8 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
         global $CFG;
         $this->page->requires->js('/question/type/formulas/script/formatcheck.js');
         // Include backwards-compatibility layer for Bootstrap 4 data attributes, if available.
-        if (file_exists($CFG->dirroot . '/question/type/formulas/questiontype.php')) {
+        // We may safely assume that if the uncompbiled version is there, the minified one exists as well.
+        if (file_exists($CFG->dirroot . '/theme/boost/amd/src/bs4-compat.js')) {
             $this->page->requires->js_call_amd('theme_boost/bs4-compat', 'initBootstrap4Compatibility');
         }
         return '';

--- a/renderer.php
+++ b/renderer.php
@@ -97,12 +97,14 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
         $this->page->requires->js('/question/type/formulas/script/formatcheck.js');
         // Include backwards-compatibility layer for Bootstrap 4 data attributes, if available.
         // We may safely assume that if the uncompbiled version is there, the minified one exists as well.
-        // We generate code similar to what js_call_amd() does, but we cannot use it directly,
-        // because it would try to call BS4Compat.() rather than BS4Compat().
         if (file_exists($CFG->dirroot . '/theme/boost/amd/src/bs4-compat.js')) {
-            $code = "M.util.js_pending('theme_boost/bs4-compat'); ";
-            $code .= "require(['theme_boost/bs4-compat'], function(BS4Compat) { BS4Compat(); });";
-            $code .= "M.util.js_complete('theme_boost/bs4-compat');";
+            // We generate code similar to what js_call_amd() does, but we cannot use that function directly,
+            // because (written in the style below) it would try to call BS4Compat.() rather than BS4Compat().
+            $code = <<<EOF
+                M.util.js_pending('theme_boost/bs4-compat');
+                require(['theme_boost/bs4-compat'], function(BS4Compat) { BS4Compat(); });
+                M.util.js_complete('theme_boost/bs4-compat');
+            EOF;
             $this->page->requires->js_amd_inline($code);
         }
         return '';

--- a/renderer.php
+++ b/renderer.php
@@ -31,6 +31,9 @@
  */
 class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
 
+    /** @var bool track whether the JS header code has already been sent */
+    protected static $jsheaderloaded = false;
+
     /**
      * Generate the display of the formulation part of the question. This is the
      * area that contains the question text, and the controls for students to
@@ -94,12 +97,16 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
      */
     public function head_code(question_attempt $qa) {
         global $CFG;
+        if (self::$jsheaderloaded) {
+            return '';
+        }
         $this->page->requires->js('/question/type/formulas/script/formatcheck.js');
         // Include backwards-compatibility layer for Bootstrap 4 data attributes, if available.
         // We may safely assume that if the uncompbiled version is there, the minified one exists as well.
         if (file_exists($CFG->dirroot . '/theme/boost/amd/src/bs4-compat.js')) {
             $this->page->requires->js_call_amd('theme_boost/bs4-compat', 'initBootstrap4Compatibility');
         }
+        self::$jsheaderloaded = true;
         return '';
     }
 

--- a/renderer.php
+++ b/renderer.php
@@ -94,6 +94,7 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
      */
     public function head_code(question_attempt $qa) {
         $this->page->requires->js('/question/type/formulas/script/formatcheck.js');
+        $this->page->requires->js_call_amd('theme_boost/bs4-compat', 'initBootstrap4Compatibility');
         return '';
     }
 

--- a/renderer.php
+++ b/renderer.php
@@ -93,8 +93,12 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
      * @return string HTML fragment
      */
     public function head_code(question_attempt $qa) {
+        global $CFG;
         $this->page->requires->js('/question/type/formulas/script/formatcheck.js');
-        $this->page->requires->js_call_amd('theme_boost/bs4-compat', 'initBootstrap4Compatibility');
+        // Include backwards-compatibility layer for Bootstrap 4 data attributes, if available.
+        if (file_exists($CFG->dirroot . '/question/type/formulas/questiontype.php')) {
+            $this->page->requires->js_call_amd('theme_boost/bs4-compat', 'initBootstrap4Compatibility');
+        }
         return '';
     }
 
@@ -264,12 +268,13 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
             $variablename = "{$i}_";
             $currentanswer = $qa->get_last_qt_var($variablename);
             $inputname = $qa->get_qt_field_name($variablename);
+            $title = get_string($gtype . ($part->postunit == '' ? '' : '_unit'), 'qtype_formulas');
             $inputattributes = [
                 'type' => 'text',
                 'name' => $inputname,
                 'data-toggle' => 'tooltip',
-                'data-title' => get_string($gtype . ($part->postunit == '' ? '' : '_unit'), 'qtype_formulas'),
-                'title' => get_string($gtype . ($part->postunit == '' ? '' : '_unit'), 'qtype_formulas'),
+                'data-title' => $title,
+                'title' => $title,
                 'value' => $currentanswer,
                 'id' => $inputname,
                 'class' => 'form-control formulas_' . $gtype . '_unit ' . $sub->feedbackclass,
@@ -309,13 +314,14 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
             $variablename = "{$i}_$j";
             $currentanswer = $qa->get_last_qt_var($variablename);
             $inputname = $qa->get_qt_field_name($variablename);
+            $title = get_string($placeholder == '_u' ? 'unit' : $gtype, 'qtype_formulas');
             $inputattributes = [
                 'name' => $inputname,
                 'value' => $currentanswer,
                 'id' => $inputname,
                 'data-toggle' => 'tooltip',
-                'data-title' => get_string($gtype . ($part->postunit == '' ? '' : '_unit'), 'qtype_formulas'),
-                'title' => get_string($gtype . ($part->postunit == '' ? '' : '_unit'), 'qtype_formulas'),
+                'data-title' => $title,
+                'title' => $title,
                 'maxlength' => 128,
                 'aria-labelledby' => 'lbl_' . str_replace(':', '__', $inputname),
             ];

--- a/renderer.php
+++ b/renderer.php
@@ -31,9 +31,6 @@
  */
 class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
 
-    /** @var bool track whether the JS header code has already been sent */
-    protected static $jsheaderloaded = false;
-
     /**
      * Generate the display of the formulation part of the question. This is the
      * area that contains the question text, and the controls for students to
@@ -97,16 +94,17 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
      */
     public function head_code(question_attempt $qa) {
         global $CFG;
-        if (self::$jsheaderloaded) {
-            return '';
-        }
         $this->page->requires->js('/question/type/formulas/script/formatcheck.js');
         // Include backwards-compatibility layer for Bootstrap 4 data attributes, if available.
         // We may safely assume that if the uncompbiled version is there, the minified one exists as well.
+        // We generate code similar to what js_call_amd() does, but we cannot use it directly,
+        // because it would try to call BS4Compat.() rather than BS4Compat().
         if (file_exists($CFG->dirroot . '/theme/boost/amd/src/bs4-compat.js')) {
-            $this->page->requires->js_call_amd('theme_boost/bs4-compat');
+            $code = "M.util.js_pending('theme_boost/bs4-compat'); ";
+            $code .= "require(['theme_boost/bs4-compat'], function(BS4Compat) { BS4Compat(); });";
+            $code .= "M.util.js_complete('theme_boost/bs4-compat');";
+            $this->page->requires->js_amd_inline($code);
         }
-        self::$jsheaderloaded = true;
         return '';
     }
 

--- a/renderer.php
+++ b/renderer.php
@@ -104,7 +104,7 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
         // Include backwards-compatibility layer for Bootstrap 4 data attributes, if available.
         // We may safely assume that if the uncompbiled version is there, the minified one exists as well.
         if (file_exists($CFG->dirroot . '/theme/boost/amd/src/bs4-compat.js')) {
-            $this->page->requires->js_call_amd('theme_boost/bs4-compat', 'initBootstrap4Compatibility');
+            $this->page->requires->js_call_amd('theme_boost/bs4-compat');
         }
         self::$jsheaderloaded = true;
         return '';

--- a/script/formatcheck.js
+++ b/script/formatcheck.js
@@ -607,7 +607,7 @@ function formulas_format_check() {
             self.last_value = null; // the input value in the last checking state, nothing by default.
             self.func = type.func;
             self.show_info = (type.show_type || type.show_interpretation);
-            self.show_type = type.show_type;
+            self.show_type = false;
             self.show_sign = type.show_sign;
             self.show_interpretation = type.show_interpretation;
             self.title = input.title;

--- a/styles.css
+++ b/styles.css
@@ -155,7 +155,7 @@ body#page-question-type-formulas .formulas_input_warning {
     background: transparent;
     left: -1.3em;
     position: absolute;
-    top: 0.3em;
+    top: 0.6em;
 }
 
 body#page-question-type-formulas .formulas_input_info_outer {

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,4 @@
 .que.formulas .formulas_input_warning_outer {
-
     display: inline;
     position: absolute;
     z-index: 1;
@@ -9,7 +8,7 @@
     background: transparent;
     left: -1.3em;
     position: absolute;
-    top: 0.3em;
+    top: 0.6em;
 }
 
 .que.formulas .formulas_input_info_outer {
@@ -20,7 +19,6 @@
 
 .que.formulas .formulas_input_info {
     background-color: #eef;
-    border: 1px solid #88c;
     left: 0;
     position: absolute;
     top: 1.63em;
@@ -32,57 +30,66 @@
 }
 
 .que.formulas .formulas_input_info_interpretation {
-    border-top: 1px solid #88c;
+    border: 1px solid #88c;
     padding: 2px;
 }
 
 .que.formulas .formulas_input_info_interpretation_incorrect {
-    border-top: 1px solid #88c;
+    border: 1px solid #88c;
     color: #bbb;
     padding: 2px;
 }
 
 .que.formulas .formulas_unit {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 40px;
 }
 
 .que.formulas .formulas_number {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 40px;
 }
 
 .que.formulas .formulas_number_unit {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 80px;
 }
 
 .que.formulas .formulas_numeric {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 100px;
 }
 
 .que.formulas .formulas_numeric_unit {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 200px;
 }
 
 .que.formulas .formulas_numerical_formula {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 200px;
 }
 
 .que.formulas .formulas_numerical_formula_unit {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 300px;
 }
 
 .que.formulas .formulas_algebraic_formula {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 200px;
 }
 
 .que.formulas .formulas_algebraic_formula_unit {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 300px;
 }
@@ -139,7 +146,6 @@ body#page-question-type-formulas .formulas_correctness_show {
 }
 
 body#page-question-type-formulas .formulas_input_warning_outer {
-
     display: inline;
     position: absolute;
     z-index: 1;
@@ -160,7 +166,6 @@ body#page-question-type-formulas .formulas_input_info_outer {
 
 body#page-question-type-formulas .formulas_input_info {
     background-color: #eef;
-    border: 1px solid #88c;
     left: 0;
     position: absolute;
     top: 1.94em;
@@ -172,12 +177,12 @@ body#page-question-type-formulas .formulas_input_info_title {
 }
 
 body#page-question-type-formulas .formulas_input_info_interpretation {
-    border-top: 1px solid #88c;
+    border: 1px solid #88c;
     padding: 2px;
 }
 
 body#page-question-type-formulas .formulas_input_info_interpretation_incorrect {
-    border-top: 1px solid #88c;
+    border: 1px solid #88c;
     color: #bbb;
     padding: 2px;
 }

--- a/tests/backup_restore_test.php
+++ b/tests/backup_restore_test.php
@@ -670,7 +670,10 @@ final class backup_restore_test extends \advanced_testcase {
         $DB->set_field('question', 'stamp', $question1->stamp, ['id' => $question2->id]);
 
         // Change the options of question2 to be different to question1.
-        $optionfields = ['varsrandom', 'varsglobal', 'answernumbering', 'shownumcorrect', 'correctfeedback', 'partiallycorrectfeedback', 'incorrectfeedback'];
+        $optionfields = [
+            'varsrandom', 'varsglobal', 'answernumbering', 'shownumcorrect',
+            'correctfeedback', 'partiallycorrectfeedback', 'incorrectfeedback',
+        ];
         if (in_array($field, $optionfields)) {
             $DB->set_field('qtype_formulas_options', $field, $value, ['questionid' => $question2->id]);
         } else {

--- a/tests/behat/behat_qtype_formulas.php
+++ b/tests/behat/behat_qtype_formulas.php
@@ -64,6 +64,7 @@ class behat_qtype_formulas extends behat_base {
         $this->execute("behat_general::i_click_on", [$this->escape($xpath), "xpath_element"]);
     }
 
+    // phpcs:disable moodle.Files.LineLength.TooLong
     /**
      * Check values inside the instantiation table.
      *
@@ -75,6 +76,7 @@ class behat_qtype_formulas extends behat_base {
      * @param int $rownumber which row
      */
     public function i_should_see_in_the_field_of_row_of_the_formulas_question_instatiation_table(string $text, string $field, int $rownumber): void {
+        // phpcs:enable
         $field = behat_context_helper::escape($field);
 
         $xpath = "//div[contains(@class, 'tabulator-row')][not(contains(@class, 'tabulator-calc'))][$rownumber]"

--- a/tests/behat/edit.feature
+++ b/tests/behat/edit.feature
@@ -57,6 +57,8 @@ Feature: Test editing a Formulas question
 
   Scenario: Check validation of grading vars
     When I am on the "formulas-001 for editing" "core_question > edit" page logged in as teacher1
+    And I follow "Part 1"
+    And I follow "Show more..."
     And I set the following fields to these values:
       | Grading variables | test = 1/0; |
     And I press "id_submitbutton"

--- a/tests/behat/tooltips.feature
+++ b/tests/behat/tooltips.feature
@@ -1,0 +1,97 @@
+@qtype @qtype_formulas @javascript
+Feature: Display of tooltips
+
+  Background:
+    Given the following "users" exist:
+      | username |
+      | student  |
+    And the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1        | 0        |
+    And the following "course enrolments" exist:
+      | user    | course | role    |
+      | student | C1     | student |
+    And the following "question categories" exist:
+      | contextlevel | reference | name           |
+      | Course       | C1        | Test questions |
+    And the following "questions" exist:
+      | questioncategory | qtype    | name             | template             |
+      | Test questions   | formulas | singlenum        | testsinglenum        |
+      | Test questions   | formulas | singlenumunit    | testsinglenumunit    |
+      | Test questions   | formulas | singlenumunitsep | testsinglenumunitsep |
+      | Test questions   | formulas | threeparts       | testthreeparts       |
+      | Test questions   | formulas | algebraic        | testalgebraic        |
+      | Test questions   | formulas | twoandtwo        | testtwoandtwo        |
+    And the following "activities" exist:
+      | activity | name   | course | idnumber |
+      | quiz     | Quiz 1 | C1     | quiz1    |
+      | quiz     | Quiz 2 | C1     | quiz2    |
+      | quiz     | Quiz 3 | C1     | quiz3    |
+      | quiz     | Quiz 4 | C1     | quiz4    |
+      | quiz     | Quiz 5 | C1     | quiz5    |
+    And quiz "Quiz 1" contains the following questions:
+      | question  | page |
+      | singlenum | 1    |
+    And quiz "Quiz 2" contains the following questions:
+      | question  | page |
+      | algebraic | 1    |
+    And quiz "Quiz 3" contains the following questions:
+      | question      | page |
+      | singlenumunit | 1    |
+    And quiz "Quiz 4" contains the following questions:
+      | question         | page |
+      | singlenumunitsep | 1    |
+    And quiz "Quiz 5" contains the following questions:
+      | question  | page |
+      | twoandtwo | 1    |
+    And I log in as "student"
+    And I am on "Course 1" course homepage
+
+  Scenario: Try to answer a question with one part and one answer field
+    When I follow "Quiz 1"
+    And I press "Attempt quiz"
+    And I set the field "Answer" to "5"
+    Then I should see "Number"
+    And I press tab
+    Then I should not see "Number"
+    And "div.tooltip-inner" "css_element" should not exist
+
+  Scenario: Try to answer a question with an algebraic formula answer
+    When I follow "Quiz 2"
+    And I press "Attempt quiz"
+    And I set the field "Answer" to "x"
+    Then I should see "Algebraic formula"
+    And I press tab
+    Then I should not see "Algebraic formula"
+    And "div.tooltip-inner" "css_element" should not exist
+
+  Scenario: Try to answer a question with one combined answer+unit field
+    When I follow "Quiz 3"
+    And I press "Attempt quiz"
+    And I set the field "Answer" to "5 m/s"
+    Then I should see "Number and unit"
+    And I press tab
+    Then I should not see "Number and unit"
+    And "div.tooltip-inner" "css_element" should not exist
+
+  Scenario: Try to answer a question with one answer + one unit field
+    When I follow "Quiz 4"
+    And I press "Attempt quiz"
+    And I set the field "Answer" to "5"
+    Then I should see "Number" in the "div.tooltip-inner" "css_element"
+    And I should not see "Unit" in the "div.tooltip-inner" "css_element"
+    And I set the field "Unit" to "m/s"
+    Then I should not see "Number" in the "div.tooltip-inner" "css_element"
+    And I should see "Unit" in the "div.tooltip-inner" "css_element"
+    And I should see "Unit"
+    And I press tab
+    Then "div.tooltip-inner" "css_element" should not exist
+
+  Scenario: Try to answer a question with multiple input fields
+    When I follow "Quiz 5"
+    And I press "Attempt quiz"
+    And I set the field "Answer field 1 for part 1" to "1"
+    Then I should see "Number"
+    And I press shift tab
+    Then I should not see "Number"
+    And "div.tooltip-inner" "css_element" should not exist

--- a/tests/functions_test.php
+++ b/tests/functions_test.php
@@ -616,6 +616,7 @@ final class functions_test extends \advanced_testcase {
             ["Invalid number of arguments for function 'decbin': 2 given.", 'decbin(1, 2)'],
             // TODO: enable the following test once we drop support for PHP 7.4
             // the following will not throw an error in PHP 7.4; result will be 0.
+            // phpcs:ignore
             // ['1:1:decbin(): Argument #1 ($num) must be of type int, string given', 'decbin("a")'],
         ];
     }
@@ -639,6 +640,7 @@ final class functions_test extends \advanced_testcase {
             ["Invalid number of arguments for function 'dechex': 2 given.", 'dechex(1, 2)'],
             // TODO: enable the following test once we drop support for PHP 7.4
             // the following will not throw an error in PHP 7.4; result will be 0.
+            // phpcs:ignore
             // ['1:1:dechex(): Argument #1 ($num) must be of type int, string given', 'dechex("a")'],
         ];
     }
@@ -662,6 +664,7 @@ final class functions_test extends \advanced_testcase {
             ["Invalid number of arguments for function 'bindec': 2 given.", 'bindec(1, 2)'],
             // TODO: enable the following test once we drop support for PHP 7.4
             // the following will not throw an error in PHP 7.4; result will be 0.
+            // phpcs:ignore
             // ['1:1:bindec(): Argument #1 ($num) must be of type int, string given', 'bindec("a")'],
         ];
     }
@@ -683,6 +686,7 @@ final class functions_test extends \advanced_testcase {
             ["Invalid number of arguments for function 'decoct': 2 given.", 'decoct(1, 2)'],
             // TODO: enable the following test once we drop support for PHP 7.4
             // the following will not throw an error in PHP 7.4; result will be 0.
+            // phpcs:ignore
             // ['1:1:decoct(): Argument #1 ($num) must be of type int, string given', 'decoct("a")'],
         ];
 
@@ -707,6 +711,7 @@ final class functions_test extends \advanced_testcase {
             ["Invalid number of arguments for function 'octdec': 2 given.", 'octdec(1, 2)'],
             // TODO: enable the following test once we drop support for PHP 7.4
             // the following will not throw an error in PHP 7.4; result will be 0.
+            // phpcs:ignore
             // ['1:1:octdec(): Argument #1 ($num) must be of type int, string given', 'octdec("a")'],
         ];
     }


### PR DESCRIPTION
Currently, Formulas questions use their own implementation to show a tooltip indicating the expected answer type (number, numeric etc.). However, Moodle ships with Bootstrap with provides a good and easy-to-use interface to show tooltips. This PR disables our own tooltips and changes the renderer in order to use the Bootstrap tooltips. This is also a step towards eliminating the old formatcheck.js.

Additionally, the PR adds acceptance tests to verify the tooltips are shown and hidden as expected.

Finally, the PR adds the `form-control` class to our input fields in order for them to be displayed like other Moodle form fields; in the Boost theme that means they will have rounded corners. Some changes to the style sheet were necessary, e. g. adding `display: inline-block` to input fields, because with the `form-control` class, they would have been set to `display: block`.