### PR TITLE
Leaving newly added part should give no error

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -816,17 +816,20 @@ class qtype_formulas extends question_type {
             // local vars.
             // Note that data from the editors is stored in an array with the keys text, format and itemid.
             // Also note that local vars are entered in a textarea (and not an editor) and are PARAM_RAW_TRIMMED.
-            $noparttext = empty(trim($data->subqtext[$i]['text']));
-            $nogeneralfb = empty(trim($data->subqtext[$i]['text']));
-            $nolocalvars = empty($data->vars1[$i]);
+            $noparttext = strlen(trim($data->subqtext[$i]['text'])) === 0;
+            $nogeneralfb = strlen(trim($data->subqtext[$i]['text'])) === 0;
+            $nolocalvars = strlen(trim($data->vars1[$i])) === 0;
             $emptypart = $noparttext && $nogeneralfb && $nolocalvars;
 
             // Having no answermark is only allowed if the part is "empty" AND if there is no answer.
             if ($nomark && !($emptypart && $noanswer)) {
                 $errors["answermark[$i]"] = get_string('error_mark', 'qtype_formulas');
             }
-            // Similarly, having no answer is only allowed for "empty" parts that do not have an answermark.
-            if ($noanswer && !($emptypart && $nomark)) {
+            // On the other hand, having no answer is allowed for "empty" parts even if they
+            // do have an answermark. We do this, because the answermark field is set by default when
+            // the user clicks the "Blanks for 2 more parts" button. But if they do that by accident
+            // and don't want those parts, they should not have to worry about them.
+            if ($noanswer && !$emptypart) {
                 $errors["answer[$i]"] = get_string('error_answer_missing', 'qtype_formulas');
             }
 

--- a/tests/behat/edit.feature
+++ b/tests/behat/edit.feature
@@ -71,10 +71,7 @@ Feature: Test editing a Formulas question
 
   Scenario: Adding additional parts that we don't actually want
     When I am on the "simple" "core_question > edit" page logged in as teacher1
-    Then I should not see "Part 2"
-    And I should not see "Part 3"
     And I press "id_addanswers"
-    And I wait until the page is ready
     Then I should see "Part 2"
     And I should see "Part 3"
     And I press "id_updatebutton"

--- a/tests/behat/edit.feature
+++ b/tests/behat/edit.feature
@@ -20,6 +20,7 @@ Feature: Test editing a Formulas question
     And the following "questions" exist:
       | questioncategory | qtype    | name                     | template       |
       | Test questions   | formulas | formulas-001 for editing | testthreeparts |
+      | Test questions   | formulas | simple                   | testsinglenum  |
 
   Scenario: Edit a Formulas question
     When I am on the "formulas-001 for editing" "core_question > edit" page logged in as teacher1
@@ -67,3 +68,16 @@ Feature: Test editing a Formulas question
       | Grading variables | test = 2; |
     And I press "id_submitbutton"
     Then I should not see "Division by zero is not defined."
+
+  Scenario: Adding additional parts that we don't actually want
+    When I am on the "simple" "core_question > edit" page logged in as teacher1
+    Then I should not see "Part 2"
+    And I should not see "Part 3"
+    And I press "id_addanswers"
+    And I wait until the page is ready
+    Then I should see "Part 2"
+    And I should see "Part 3"
+    And I press "id_updatebutton"
+    Then I should not see "No answer has been defined."
+    And I should not see "Part 2"
+    And I should not see "Part 3"

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -217,6 +217,8 @@ final class questiontype_test extends \advanced_testcase {
                     'answer' => [0 => ''],
                 ],
             ],
+            // The following should be valid, because the first part has no answer and no text.
+            [[], ['answer' => [0 => ''], 'subqtext' => ['0' => ['text' => '']]]],
             // The question has subqtexts defined for both parts, so the first part MUST have an answermark
             // and an answer.
             [


### PR DESCRIPTION
We want to be careful not to remove a seemingly empty part too quickly from the edit form. In the current state, however, if a part contains only an `answermark`, an error will be given ("No answer has been defined."). This should not happen, because whenever a user adds fields for 2 more parts in the edit form, these parts will have an `answermark` (by default) with all other fields being empty. So if the user now tries to save the part, they will get an error message. They must then remove the `answermark` for the newly added parts in order for them to be removed.

This PR fixes the problem. Also, as this has not been detected by automatic tests, an additional behat test has been added.