### PR TITLE
Do not use tooltip in Moodle App

### DIFF
--- a/db/mobile.php
+++ b/db/mobile.php
@@ -31,7 +31,7 @@ $addons = [
                 'method' => 'mobile_get_formulas',
                 'styles' => [
                     'url' => '/question/type/formulas/mobile/styles_app.css',
-                    'version' => '1.00',
+                    'version' => '2.0',
                 ],
             ],
         ],

--- a/mobile/mobile.js
+++ b/mobile/mobile.js
@@ -23,6 +23,10 @@ var result = {
     componentInit: function() {
         var div = document.createElement('div');
         div.innerHTML = this.question.html;
+
+        // We use Bootstrap tooltips in the classic renderer, but we don't want them in the
+        // Moodle App, because they can take away the focus.
+        div.innerHTML = div.innerHTML.replaceAll(/data(-bs)?-toggle="tooltip"/g, '');
         this.question.text = div.querySelector('.qtext').innerHTML;
 
         // Replace Moodle's correct/incorrect and feedback classes with our own.

--- a/mobile/styles_app.css
+++ b/mobile/styles_app.css
@@ -1,88 +1,53 @@
-.que.formulas .formulas_input_warning_outer {
-
-    display: inline;
-    position: absolute;
-    z-index: 1;
-}
-
-.que.formulas .formulas_input_warning {
-    background: transparent;
-    left: -1.3em;
-    position: absolute;
-    top: 0.3em;
-}
-
-.que.formulas .formulas_input_info_outer {
-    display: inline;
-    position: absolute;
-    z-index: 2;
-}
-
-.que.formulas .formulas_input_info {
-    background-color: #eef;
-    border: 1px solid #88c;
-    left: 0;
-    position: absolute;
-    top: 1.63em;
-    width: 150px;
-}
-
-.que.formulas .formulas_input_info_title {
-    padding: 2px;
-}
-
-.que.formulas .formulas_input_info_interpretation {
-    border-top: 1px solid #88c;
-    padding: 2px;
-}
-
-.que.formulas .formulas_input_info_interpretation_incorrect {
-    border-top: 1px solid #88c;
-    color: #bbb;
-    padding: 2px;
-}
-
 .que.formulas .formulas_unit {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 40px;
 }
 
 .que.formulas .formulas_number {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 40px;
 }
 
 .que.formulas .formulas_number_unit {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 80px;
 }
 
 .que.formulas .formulas_numeric {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 100px;
 }
 
 .que.formulas .formulas_numeric_unit {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 200px;
 }
 
 .que.formulas .formulas_numerical_formula {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 200px;
 }
 
 .que.formulas .formulas_numerical_formula_unit {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 300px;
 }
 
 .que.formulas .formulas_algebraic_formula {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 200px;
 }
 
 .que.formulas .formulas_algebraic_formula_unit {
+    display: inline-block;
     margin: 0 0 0 0;
     width: 300px;
 }
@@ -104,7 +69,6 @@
     padding: 0.3em 0 0.3em 25px;
     text-indent: -25px;
 }
-
 
 .que.formulas .formulas_mark {
     display: inline;
@@ -131,61 +95,4 @@
 .que.formulas .formulation .formulaspartfeedback .partiallycorrect,
 .que.formulas .formulation .formulaspartfeedback .incorrect {
     background: transparent;
-}
-
-/* Styles for the editing form. */
-body#page-question-type-formulas .formulas_correctness_show {
-    display: inline;
-}
-
-body#page-question-type-formulas .formulas_input_warning_outer {
-
-    display: inline;
-    position: absolute;
-    z-index: 1;
-}
-
-body#page-question-type-formulas .formulas_input_warning {
-    background: transparent;
-    left: -1.3em;
-    position: absolute;
-    top: 0.3em;
-}
-
-body#page-question-type-formulas .formulas_input_info_outer {
-    display: inline;
-    position: absolute;
-    z-index: 2;
-}
-
-body#page-question-type-formulas .formulas_input_info {
-    background-color: #eef;
-    border: 1px solid #88c;
-    left: 0;
-    position: absolute;
-    top: 1.94em;
-    width: 150px;
-}
-*/
-body#page-question-type-formulas .formulas_input_info_title {
-    padding: 2px;
-}
-
-body#page-question-type-formulas .formulas_input_info_interpretation {
-    border-top: 1px solid #88c;
-    padding: 2px;
-}
-
-body#page-question-type-formulas .formulas_input_info_interpretation_incorrect {
-    border-top: 1px solid #88c;
-    color: #bbb;
-    padding: 2px;
-}
-
-/* RTL hacks */
-#page-question-type-formulas #id_varsrandom,
-#page-question-type-formulas #id_varsglobal {
-    height: 80px;
-    direction: ltr;
-    text-align: left;
 }


### PR DESCRIPTION
The tooltip could take away focus from the input field, so we remove it when rendering content for the Moodle App. Note that tooltips have not been present in the app before anyway.