### PR TITLE
Write compatibility layer for unit expressions

### DIFF
--- a/classes/local/parser.php
+++ b/classes/local/parser.php
@@ -33,7 +33,7 @@ class parser {
     protected array $tokenlist;
 
     /** @var int number of (raw) tokens */
-    private int $count;
+    protected int $count;
 
     /** @var int position w.r.t. list of (raw) tokens */
     private int $position = -1;
@@ -98,7 +98,7 @@ class parser {
      *
      * @return void
      */
-    private function check_unbalanced_parens(): void {
+    protected function check_unbalanced_parens(): void {
         $parenstack = [];
         foreach ($this->tokenlist as $token) {
             $type = $token->type;
@@ -399,7 +399,7 @@ class parser {
      *
      * @return token|null
      */
-    private function read_next(): ?token {
+    protected function read_next(): ?token {
         $nexttoken = $this->peek();
         if ($nexttoken !== self::EOF) {
             $this->position++;

--- a/classes/local/shunting_yard.php
+++ b/classes/local/shunting_yard.php
@@ -622,6 +622,12 @@ class shunting_yard {
                     if ($value === '^') {
                         $value = '**';
                     }
+                    // Exponents cannot follow a closing parenthesis, because things like (m/s)^2 cannot
+                    // be translated to legacy syntax before "unit arithmetic" is fully implemented. We use
+                    // $token->value instead of $value to have the operator like it was entered.
+                    if ($value === '**' && $lasttype === token::CLOSING_PAREN) {
+                        self::die(get_string('error_unexpectedtoken', 'qtype_formulas', $token->value), $token);
+                    }
                     $thisprecedence = self::get_precedence($value);
                     // We artificially increase the precedence of the division operator, because
                     // legacy versions used implicit parens around the denominator, e. g.

--- a/classes/local/shunting_yard.php
+++ b/classes/local/shunting_yard.php
@@ -609,10 +609,6 @@ class shunting_yard {
 
                 // Deal with all the possible operators...
                 case token::OPERATOR:
-                    // Expressions must not start with an operator.
-                    if (is_null($lasttoken)) {
-                        self::die(get_string('error_unexpectedtoken', 'qtype_formulas', $value), $token);
-                    }
                     // Operators must not follow an opening parenthesis, except for the unary minus.
                     if ($lasttype === token::OPENING_PAREN && $value !== '-') {
                         self::die(get_string('error_unexpectedtoken', 'qtype_formulas', $value), $token);
@@ -646,11 +642,6 @@ class shunting_yard {
                     // Put the operator on the stack.
                     $opstack[] = $token;
                     break;
-
-                // If we still haven't dealt with the token, there must be a problem with the input.
-                default:
-                    self::die(get_string('error_unexpectedtoken', 'qtype_formulas', $value), $token);
-
             }
 
             $lasttoken = $token;

--- a/classes/local/token.php
+++ b/classes/local/token.php
@@ -123,6 +123,9 @@ class token {
     /** @var int used to designate a token storing an end-of-group marker (closing brace) */
     const END_GROUP = 4194304;
 
+    /** @var int used to designate a token storing a unit */
+    const UNIT = 8388608;
+
     /** @var mixed the token's content, will be the name for identifiers */
     public $value;
 

--- a/classes/local/unit_parser.php
+++ b/classes/local/unit_parser.php
@@ -1,0 +1,256 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace qtype_formulas\local;
+
+/*
+
+Notes about current implementation:
+
+- only 2 operators allowed: ^ for exponentiation and / for division
+- only one / allowed
+- no * allowed
+- no parens allowed, except in exponent or around the *entire* denominator
+- right side of / is considered in parens, even if not written, e.g. J/m*K --> J / (m*K)
+- only units, no numbers except for exponents
+- positive or negative exponents allowed
+- negative exponents allowed with or without parens
+- same unit not allowed more than once
+
+Future implementation, must be 100% backwards compatible
+
+- allow parens everywhere
+- allow * for explicit multiplication of units
+- still only allow one /
+- still not allow same unit more than once
+- if * is used after /, assume implicit parens, e. g. J / m * K --> J / (m * K)
+- do not allow operators other than *, / and ^ as well as unary - (in exponents only)
+- allow ** instead of ^
+
+*/
+
+
+/**
+ * Parser for units for qtype_formulas
+ *
+ * @package    qtype_formulas
+ * @copyright  2025 Philipp Imhof
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class unit_parser extends parser {
+
+    /** @var array list of used units */
+    private array $unitlist = [];
+
+    /**
+     * Create a unit parser class and have it parse a given input. The input can be given as a string, in
+     * which case it will first be sent to the lexer. If that step has already been made, the constructor
+     * also accepts a list of tokens.
+     *
+     * @param string|array $tokenlist list of tokens as returned from the lexer or input string
+     */
+    public function __construct($tokenlist) {
+        // If the input is given as a string, run it through the lexer first.
+        if (is_string($tokenlist)) {
+            $lexer = new lexer($tokenlist);
+            $tokenlist = $lexer->get_tokens();
+        }
+        $this->tokenlist = $tokenlist;
+        $this->count = count($tokenlist);
+
+        // Check for unbalanced / mismatched parentheses.
+        $this->check_parens();
+
+        // Whether we have already seen a slash or the number one (except in exponents).
+        $seenslash = false;
+        $seenunit = false;
+        $inexponent = false;
+        foreach ($tokenlist as $token) {
+            // The use of functions is not permitted in units, so all identifiers will be classified
+            // as UNIT tokens.
+            if ($token->type === token::IDENTIFIER) {
+                // If inside an exponent, only numbers (and maybe the unary minus) are allowed.
+                if ($inexponent) {
+                    $this->die(get_string('error_unexpectedtoken', 'qtype_formulas', $token->value), $token);
+                }
+                // The same unit must not be used more than once.
+                if ($this->has_unit_been_used($token)) {
+                    $this->die('Unit already used: ' . $token->value, $token);
+                }
+                $this->unitlist[] = $token->value;
+                $token->type = token::UNIT;
+                $seenunit = true;
+                continue;
+            }
+
+            // Do various syntax checks for operators.
+            if ($token->type === token::OPERATOR) {
+                // We can only accept an operator if there has been at least one unit before.
+                if (!$seenunit) {
+                    $this->die(get_string('error_unexpectedtoken', 'qtype_formulas', $token->value), $token);
+                }
+                // The only operators allowed are exponentiation, multiplication, division and the unary minus.
+                // Note that the caret (^) always means exponentiation in the context of units.
+                if (!in_array($token->value, ['^', '**', '/', '*', '-'])) {
+                    $this->die(get_string('error_unexpectedtoken', 'qtype_formulas', $token->value), $token);
+                }
+                // The unary minus is only allowed inside an exponent.
+                if ($token->value === '-' && !$inexponent) {
+                    $this->die(get_string('error_unexpectedtoken', 'qtype_formulas', $token->value), $token);
+                }
+                // Only the unary minus is allowed inside an exponent.
+                if ($inexponent && $token->value !== '-') {
+                    $this->die(get_string('error_unexpectedtoken', 'qtype_formulas', $token->value), $token);
+                }
+                if ($token->value === '^' || $token->value === '**') {
+                    $inexponent = true;
+                }
+                if ($token->value === '/') {
+                    if ($seenslash) {
+                        $this->die(get_string('error_unexpectedtoken', 'qtype_formulas', $token->value), $token);
+                    }
+                    $seenslash = true;
+                }
+                continue;
+            }
+
+            // Numbers can only be used as exponents and exponents must always be integers.
+            if ($token->type === token::NUMBER) {
+                if (!$inexponent) {
+                    $this->die(get_string('error_unexpectedtoken', 'qtype_formulas', $token->value), $token);
+                }
+                if (intval($token->value) != $token->value) {
+                    $this->die(get_string('error_integerexpected', 'qtype_formulas', $token->value), $token);
+                }
+                // Only one number is allowed in an exponent, so after the number the
+                // exponent must be finished.
+                $inexponent = false;
+                continue;
+            }
+
+            // Parentheses are allowed, but we don't have to do anything with them now.
+            if (in_array($token->type, [token::OPENING_PAREN, token::CLOSING_PAREN])) {
+                continue;
+            }
+
+            // All other tokens are not allowed.
+            $this->die(get_string('error_unexpectedtoken', 'qtype_formulas', $token->value), $token);
+        }
+
+        // The last token must be a number, a unit or a closing parenthesis.
+        $finaltoken = end($tokenlist);
+        if (!in_array($finaltoken->type, [token::UNIT, token::NUMBER, token::CLOSING_PAREN])) {
+            $this->die(get_string('error_unexpectedtoken', 'qtype_formulas', $token->value), $token);
+        }
+
+        $this->statements[] = shunting_yard::unit_infix_to_rpn($this->tokenlist);
+    }
+
+    /**
+     * Check whether a given unit has already been used.
+     *
+     * @param token $token token containing the unit
+     * @return bool
+     */
+    protected function has_unit_been_used(token $token): bool {
+        return in_array($token->value, $this->unitlist);
+    }
+
+    /**
+     * Check whether all parentheses are balanced and whether only round parens are used.
+     * Otherweise, stop all further processing and output an error message.
+     *
+     * @return void
+     */
+    protected function check_parens(): void {
+        $parenstack = [];
+        foreach ($this->tokenlist as $token) {
+            $type = $token->type;
+            // We only allow round parens.
+            if (($token->type & token::ANY_PAREN) && !($token->type & token::OPEN_OR_CLOSE_PAREN)) {
+                $this->die(get_string('error_unexpectedtoken', 'qtype_formulas', $token->value), $token);
+            }
+            if ($type === token::OPENING_PAREN) {
+                $parenstack[] = $token;
+            }
+            if ($type === token::CLOSING_PAREN) {
+                $top = end($parenstack);
+                // If stack is empty, we have a stray closing paren.
+                if (!($top instanceof token)) {
+                    $this->die(get_string('error_strayparen', 'qtype_formulas', $token->value), $token);
+                }
+                array_pop($parenstack);
+            }
+        }
+        // If the stack of parentheses is not empty now, we have an unmatched opening parenthesis.
+        if (!empty($parenstack)) {
+            $unmatched = end($parenstack);
+            $this->die(get_string('error_parennotclosed', 'qtype_formulas', $unmatched->value), $unmatched);
+        }
+    }
+
+    /**
+     * Translate the given input into a string that can be understood by the legacy unit parser, i. e.
+     * following all syntax rules. This allows keeping the old unit conversion system in place until
+     * we are readyd to eventually replace it.
+     *
+     * @return string
+     */
+    public function get_legacy_unit_string(): string {
+        $stack = [];
+
+        foreach ($this->statements[0] as $token) {
+            // Write numbers and units to the stack.
+            if (in_array($token->type, [token::UNIT, token::NUMBER])) {
+                $value = $token->value;
+                if (is_numeric($value) && $value < 0) {
+                    $value = '(' . strval($value) . ')';
+                }
+                $stack[] = $value;
+            }
+
+            // Operators take arguments from stack and stick them together in the appropriate way.
+            if ($token->type === token::OPERATOR) {
+                $op = $token->value;
+                if ($op === '**') {
+                    $op = '^';
+                }
+                if ($op === '*') {
+                    $op = ' ';
+                }
+                $second = array_pop($stack);
+                $first = array_pop($stack);
+                // With the new syntax, it is possible to write e.g. (m/s^2)*kg. In older versions,
+                // everything coming after the / operator will be considered a part of the denominator,
+                // so the only way to get the kg into the numerator is to reorder the units and
+                // write them as kg*m/s^2. Long story short: if there is a division, it must come last.
+                // Note that the syntax currently does not allow more than one /, so we do not need
+                // a more sophisticated solution.
+                if (strpos($first, '/') !== false) {
+                    list($second, $first) = [$first, $second];
+                }
+                // Legacy syntax allowed parens around the entire denominator, so we do that unless the
+                // denominator is just one unit.
+                if ($op === '/' && !preg_match('/^[A-Za-z]+$/', $second)) {
+                    $second = '(' . $second . ')';
+                }
+                $stack[] = $first . $op . $second;
+            }
+        }
+
+        return implode('', $stack);
+    }
+}

--- a/classes/local/unit_parser.php
+++ b/classes/local/unit_parser.php
@@ -43,6 +43,13 @@ class unit_parser extends parser {
         }
         $this->tokenlist = $tokenlist;
 
+        // The unit_parser might have been called on an empty input. If this is the case, we store an
+        // empty statement and stop here.
+        if (empty($this->tokenlist)) {
+            $this->statements[] = [];
+            return;
+        }
+
         // Check for unbalanced / mismatched parentheses.
         $this->check_parens();
 

--- a/classes/local/unit_parser.php
+++ b/classes/local/unit_parser.php
@@ -39,6 +39,34 @@ Future implementation, must be 100% backwards compatible
 - if * is used after /, assume implicit parens, e. g. J / m * K --> J / (m * K)
 - do not allow operators other than *, / and ^ as well as unary - (in exponents only)
 - allow ** instead of ^
+- for the moment: disallow exponent after closing paren to avoid things like (m/s)^2
+
+
+Syntax for unit conversion rules
+
+Type 1: SI prefixes
+
+<base unit> : <prefix1> <prefix2> ... <prefix-n> ;
+
+- at least one valid prefix
+- ; at end, if more statements follow
+- base unit single token, no number
+
+example:
+
+m : k da d c m u µ;
+s : m u µ;
+
+Type 2: conversion factors / arbitrary prefixes
+
+[<number>] <base unit> = <number> <target unit 1> [ = <number> <target unit 2> ...] ;
+
+- if first number not given --> 1
+- all further declarations always relative to base unit
+
+min = 60 s;
+h = 60 min;
+
 
 */
 
@@ -52,8 +80,76 @@ Future implementation, must be 100% backwards compatible
  */
 class unit_parser extends parser {
 
+    // FIXME: allow unicode chars for micro and ohm in lexer; maybe disallow for variable names (check during assignment)
+
+    const SI_PREFIX_FACTORS = [
+        'd' => 0.1,
+        'c' => 0.01,
+        'm' => 0.001,
+        'u' => 1e-6,
+        // For convenience, we also allow U+00B5 MICRO SIGN.
+        "\u{00B5}" => 1e-6,
+        // For convenience, we also allow U+03BC GREEK SMALL LETTER MU.
+        "\u{03BC}" => 1e-6,
+        'n' => 1e-9,
+        'p' => 1e-12,
+        'f' => 1e-15,
+        'a' => 1e-18,
+        'z' => 1e-21,
+        'y' => 1e-24,
+        'r' => 1e-27,
+        'q' => 1e-30,
+        'da' => 10,
+        'h' => 100,
+        'k' => 1000,
+        'M' => 1e6,
+        'G' => 1e9,
+        'T' => 1e12,
+        'P' => 1e15,
+        'E' => 1e18,
+        'Z' => 1e21,
+        'Y' => 1e24,
+        'R' => 1e27,
+        'Q' => 1e30,
+    ];
+
+    const DEFAULT_PREFIXES = [
+        's' => ['m', 'u', 'n', 'p', 'f'],
+        'm' => ['k', 'da', 'c', 'd', 'm', 'u', 'n', 'p', 'f'],
+        'g' => ['k', 'm', 'u', 'n', 'p', 'f'],
+        'A' => ['m', 'u', 'n', 'p', 'f'],
+        'mol' => ['m', 'u', 'n', 'p'],
+        'K' => ['m', 'u', 'n', 'k', 'M'],
+        'cd' => ['m', 'k', 'M', 'u', 'G'],
+        'N' => ['M', 'k', 'm', 'u', 'n', 'p', 'f'],
+        'J' => ['M', 'G', 'T', 'P', 'k', 'm', 'u', 'n', 'p', 'f'],
+        'eV' => ['M', 'G', 'T', 'P', 'k', 'm', 'u'],
+        'W' => ['M', 'G', 'T', 'P', 'k', 'm', 'u', 'n', 'p', 'f'],
+        'Pa' => ['M', 'G', 'T', 'P', 'k', 'h'],
+        'Hz' => ['M', 'G', 'T', 'P', 'E', 'k'],
+        'C' => ['k', 'm', 'u', 'n', 'p', 'f'],
+        'V' => ['M', 'G', 'k', 'm', 'u', 'n', 'p', 'f'],
+        'ohm' => ['M', 'G', 'T', 'P', 'k', 'm', 'u'],
+        'F' => ['m', 'u', 'n', 'p', 'f'],
+        'T' => ['k', 'm', 'u', 'n', 'p'],
+        'H' => ['k', 'm', 'u', 'n', 'p'],
+    ];
+
+    const DEFAULT_SPECIAL_RULES = [
+        // For convenience, we also allow U+2126 OHM SIGN.
+        "\u{2126}" => ['ohm' => 1],
+        // For convenience, we also allow U+03A9 GREEK CAPITAL LETTER OMEGA.
+        "\u{03A9}" => ['ohm' => 1],
+        'min' => ['s' => 60],
+        'h' => ['s' => 3600],
+        'J' => ['eV' => 6.24150947e+18],
+    ];
+
     /** @var array list of used units */
     private array $unitlist = [];
+
+    /** @var string list of all units with their prefixes, allowing to find base units quickly */
+    private string $baseunitmap = '';
 
     /**
      * Create a unit parser class and have it parse a given input. The input can be given as a string, in
@@ -69,16 +165,29 @@ class unit_parser extends parser {
             $tokenlist = $lexer->get_tokens();
         }
         $this->tokenlist = $tokenlist;
-        $this->count = count($tokenlist);
 
         // Check for unbalanced / mismatched parentheses.
         $this->check_parens();
 
-        // Whether we have already seen a slash or the number one (except in exponents).
+        // Perform basic syntax check, including classification of IDENTIFIER tokens
+        // to UNIT tokens.
+        $this->check_syntax();
+
+        // Run the tokens through an adapted shunting yard algorithm to bring them into
+        // RPN notation.
+        $this->statements[] = shunting_yard::unit_infix_to_rpn($this->tokenlist);
+
+        // Build base unit map that will be used to find the base unit for a given unit,
+        // e. g. find s from ms or Pa from hPa.
+        $this->build_base_unit_map();
+    }
+
+    protected function check_syntax(): void {
+        // Whether we have already seen a slash or a unit and whether we are in an exponent.
         $seenslash = false;
         $seenunit = false;
         $inexponent = false;
-        foreach ($tokenlist as $token) {
+        foreach ($this->tokenlist as $token) {
             // The use of functions is not permitted in units, so all identifiers will be classified
             // as UNIT tokens.
             if ($token->type === token::IDENTIFIER) {
@@ -96,7 +205,8 @@ class unit_parser extends parser {
                 continue;
             }
 
-            // Do various syntax checks for operators.
+            // Do various syntax checks for operators. We do them separately in order to allow
+            // for more specific error messages, if needed.
             if ($token->type === token::OPERATOR) {
                 // We can only accept an operator if there has been at least one unit before.
                 if (!$seenunit) {
@@ -151,12 +261,44 @@ class unit_parser extends parser {
         }
 
         // The last token must be a number, a unit or a closing parenthesis.
-        $finaltoken = end($tokenlist);
+        $finaltoken = end($this->tokenlist);
         if (!in_array($finaltoken->type, [token::UNIT, token::NUMBER, token::CLOSING_PAREN])) {
             $this->die(get_string('error_unexpectedtoken', 'qtype_formulas', $token->value), $token);
         }
+    }
 
-        $this->statements[] = shunting_yard::unit_infix_to_rpn($this->tokenlist);
+    protected function build_base_unit_map(): void {
+        // First, we add all the built-in default prefix rules.
+        foreach (self::DEFAULT_PREFIXES as $base => $prefixes) {
+            foreach ($prefixes as $prefix) {
+                $this->baseunitmap .= '|' . $prefix . $base . ':' . $base;
+            }
+        }
+
+        // Next, the built-in special prefix rules.
+
+
+        // Finally, we add user-defined rules.
+    }
+
+    protected function find_base_unit(string $unit): string {
+        // Example, must be built from config / rules. Format "pipe - unit with prefix - colon - base unit".
+        // Our definitions first, user's definition last.
+        $map = '|s:s|ms:s|us:s|µs:s|cm:m|dm:m|hPa:Pa|kg:g';
+
+        $matches = [];
+        preg_match_all('/\|' . $unit . ':([^|]+)/', $map, $matches);
+
+        // Array $matches has two entries, $matches[0] are full pattern matches (e.g. '|ms:s') and
+        // $matches[1] are matches of base units. If there are no matches at all, the unit was not found.
+        // This cannot normally happen. If it does, we return the unit as-is.
+        if (count($matches[1]) === 0) {
+            return $unit;
+        }
+
+        // In all other cases, we return the last possible match. In most cases there will be only one,
+        // but if there are more than one, the user-defined unit should be taken.
+        return end($matches[1]);
     }
 
     /**

--- a/lang/en/qtype_formulas.php
+++ b/lang/en/qtype_formulas.php
@@ -165,6 +165,7 @@ $string['error_grading_single_expression'] = 'The grading criterion should be on
 $string['error_import_missing_field'] = 'Import error. Missing field: {$a} ';
 $string['error_in_answer'] = 'Error in answer #{$a->answerno}: {$a->message}';
 $string['error_indexoutofrange'] = 'Evaluation error: index {$a} out of range.';
+$string['error_integerexpected'] = 'Syntax error: integer expected, found {$a} instead.';
 $string['error_inv_consec'] = 'When using inv(), the numbers in the list must be consecutive.';
 $string['error_inv_integers'] = 'inv() expects all elements of the list to be integers; floats will be truncated.';
 $string['error_inv_list'] = 'inv() expects a list.';

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -800,6 +800,32 @@ final class question_test extends \basic_testcase {
         self::assertEquals($expected, $partscores);
     }
 
+    public function test_grade_with_unit_compatibility_layer(): void {
+        $q = $this->get_test_formulas_question('testmethodsinparts');
+
+        // We overwrite the postunit. In the first part, we use the old syntax for the model unit and
+        // the new syntax in the response. In the second part, we use the new syntax for the model
+        // unit and the old syntax in the response.
+        $q->parts[0]->postunit = 'm s';
+        $q->parts[1]->postunit = 'm*s';
+
+        $q->start_attempt(new question_attempt_step(), 1);
+
+        // phpcs:ignore Universal.Arrays.DuplicateArrayKey.Found
+        $response = ['0_' => '40 m*s', '1_0' => '40', '1_1' => 'm s', '2_0' => '40', '3_0' => '40'];
+        $partscores = $q->grade_parts_that_can_be_graded($response, [], false);
+
+        // The latest $response is correct for all parts #0 and #2. Note that the penalty value will
+        // be set according to the question data; it does not mean that a deduction occurred.
+        $expected = [
+            '0' => new qbehaviour_adaptivemultipart_part_result('0', 1, 0.3),
+            '1' => new qbehaviour_adaptivemultipart_part_result('1', 1, 0.3),
+            '2' => new qbehaviour_adaptivemultipart_part_result('2', 1, 0.3),
+            '3' => new qbehaviour_adaptivemultipart_part_result('3', 1, 0.3),
+        ];
+        self::assertEquals($expected, $partscores);
+    }
+
     public function test_get_parts_and_weights_singlenum(): void {
         $q = $this->get_test_formulas_question('testsinglenum');
 

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -467,10 +467,18 @@ final class questiontype_test extends \advanced_testcase {
                     'correctness' => [0 => '1/0'],
                 ],
             ],
+            [[], ['postunit' => [0 => 'a/b*c']],
+            ],
             [
-                ['postunit[0]' => get_string('error_unit', 'qtype_formulas')],
+                ['postunit[0]' => 'Unit already used: m'],
                 [
-                    'postunit' => [0 => 'a/b*c'],
+                    'postunit' => [0 => 'm*m'],
+                ],
+            ],
+            [
+                ['postunit[0]' => 'Unexpected token: ^'],
+                [
+                    'postunit' => [0 => '(m/s)^2'],
                 ],
             ],
             [

--- a/tests/unit_parser_test.php
+++ b/tests/unit_parser_test.php
@@ -53,7 +53,7 @@ final class unit_parser_test extends \advanced_testcase {
 
         // If we are expecting an error message, the exception object should not be null and
         // the message should match, without checking row and column number.
-        if ($expected[0] === '!') {
+        if (!empty($expected) && $expected[0] === '!') {
             self::assertNotNull($e);
             self::assertStringEndsWith(substr($expected, 1), $error);
         } else {
@@ -75,7 +75,7 @@ final class unit_parser_test extends \advanced_testcase {
         }
 
         // If we are not expecting an error, check that the input has been translated as expected.
-        if ($expected[0] !== '!') {
+        if (empty($expected) || $expected[0] !== '!') {
             self::assertEquals($expected, $parser->get_legacy_unit_string());
         } else {
             self::assertNotNull($e);
@@ -91,6 +91,7 @@ final class unit_parser_test extends \advanced_testcase {
      */
     public static function provide_units(): array {
         return [
+            ['', ''],
             ['J/(m K)', 'J / m K'],
             ['J/(m K)', 'J / m*K'],
             ['J/(m K)', 'J / (m K)'],

--- a/tests/unit_parser_test.php
+++ b/tests/unit_parser_test.php
@@ -42,7 +42,7 @@ final class unit_parser_test extends \advanced_testcase {
      *
      * @dataProvider provide_units
      */
-    public function test_parse_unit($expected, $input) {
+    public function test_parse_unit($expected, $input): void {
         $e = null;
         $error = '';
         try {
@@ -66,7 +66,7 @@ final class unit_parser_test extends \advanced_testcase {
      *
      * @dataProvider provide_units
      */
-    public function test_get_legacy_unit_string($expected, $input) {
+    public function test_get_legacy_unit_string($expected, $input): void {
         $e = null;
         try {
             $parser = new unit_parser($input);
@@ -146,7 +146,27 @@ final class unit_parser_test extends \advanced_testcase {
             ['kg m^2', 'kg m^2'],
             ['kg m^2', 'kg m ^ 2'],
             ['kg m s^(-1)', 'kg m s ^ - 1'],
-            ['!Unit already used: m', 'm kg / m'],
+            ['!Syntax error: integer expected, found 2.5 instead.', 'm^2.5'],
+            ["!Unbalanced parenthesis, stray ')' found.", 'm/s)'],
+            ["!Unbalanced parenthesis, '(' is never closed.", '(m/s'],
+            ["!Unexpected input: '@'", '@'],
+            ['!Unexpected token: s', 'm^s'],
+            ['!Unexpected token: -', 'm*-s'],
+            ['!Unexpected token: /', 'm/s/K'],
+            ['!Unexpected token: /', 'm/s * kg/m^2'],
+            ['!Unexpected token: π', 'm*π'],
+            ['!Unexpected token: ,', 'm,s'],
+            ['!Unexpected token: [', '[m/s]'],
+            ['!Unexpected token: )', '(m*)'],
+            ['!Unexpected token: +', 'm+km'],
+            ['!Unexpected token: *', '*'],
+            ['!Unexpected token: *', '*m'],
+            ['!Unexpected token: /', '/m'],
+            ['!Unexpected token: *', 'm*(*s)'],
+            ['!Unexpected token: *', '(*m)'],
+            ['!Unexpected token: **', '(**m)'],
+            ['!Unexpected token: ^', '(^m)'],
+            ['!Unexpected token: {', '{m/s}'],
             ['!Unexpected token: 1', 'm 1/s'],
             ['!Unexpected token: 1', '1/s'],
             ['!Unexpected token: 1', '1 m/s'],
@@ -163,7 +183,7 @@ final class unit_parser_test extends \advanced_testcase {
             ['!Unexpected token: +', 'm^+2'],
             ['!Unexpected token: ^', '(m/s)^2'],
             ['!Unexpected token: **', '(m/s)**2'],
-            ["!Unexpected input: '@'", '@'],
+            ['!Unit already used: m', 'm kg / m'],
         ];
     }
 }

--- a/tests/unit_parser_test.php
+++ b/tests/unit_parser_test.php
@@ -22,8 +22,6 @@ global $CFG;
 require_once($CFG->dirroot . '/question/type/formulas/questiontype.php');
 
 use Exception;
-use qtype_formulas\local\lexer;
-use qtype_formulas\local\token;
 use qtype_formulas\local\unit_parser;
 
 /**
@@ -38,36 +36,6 @@ use qtype_formulas\local\unit_parser;
  * @covers \qtype_formulas\local\shunting_yard
  */
 final class unit_parser_test extends \advanced_testcase {
-
-    public function test_parse_unit_FIXME_REMOVE_WHEN_FINISHED() {
-        self::assertTrue(true);
-        return;
-        $input = '(m/s)^2';
-        $parser = new unit_parser($input);
-        var_dump($parser->get_statements()[0]);
-
-        echo $parser->get_legacy_unit_string();
-    }
-
-    public function test_parse_unit_rules_FIXME() {
-        $input = 'm: k da d c m u; s: m u; min = 60 s;';
-
-
-
-        $lexer = new lexer($input);
-        $tokens = $lexer->get_tokens();
-        var_dump($tokens);
-
-        $rules = [];
-        foreach ($tokens as $token) {
-
-
-            if ($token->type === token::END_OF_STATEMENT) {
-                $rules[] = $currentrule;
-            }
-        }
-
-    }
 
     /**
      * Test parsing of unit inputs.

--- a/tests/unit_parser_test.php
+++ b/tests/unit_parser_test.php
@@ -22,6 +22,8 @@ global $CFG;
 require_once($CFG->dirroot . '/question/type/formulas/questiontype.php');
 
 use Exception;
+use qtype_formulas\local\lexer;
+use qtype_formulas\local\token;
 use qtype_formulas\local\unit_parser;
 
 /**
@@ -33,6 +35,7 @@ use qtype_formulas\local\unit_parser;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \qtype_formulas\local\unit_parser
+ * @covers \qtype_formulas\local\shunting_yard
  */
 final class unit_parser_test extends \advanced_testcase {
 
@@ -44,6 +47,26 @@ final class unit_parser_test extends \advanced_testcase {
         var_dump($parser->get_statements()[0]);
 
         echo $parser->get_legacy_unit_string();
+    }
+
+    public function test_parse_unit_rules_FIXME() {
+        $input = 'm: k da d c m u; s: m u; min = 60 s;';
+
+
+
+        $lexer = new lexer($input);
+        $tokens = $lexer->get_tokens();
+        var_dump($tokens);
+
+        $rules = [];
+        foreach ($tokens as $token) {
+
+
+            if ($token->type === token::END_OF_STATEMENT) {
+                $rules[] = $currentrule;
+            }
+        }
+
     }
 
     /**
@@ -170,6 +193,8 @@ final class unit_parser_test extends \advanced_testcase {
             ['!Unexpected token: ^', 'm^'],
             ['!Unexpected token: /', 'm^(/2)'],
             ['!Unexpected token: +', 'm^+2'],
+            ['!Unexpected token: ^', '(m/s)^2'],
+            ['!Unexpected token: **', '(m/s)**2'],
             ["!Unexpected input: '@'", '@'],
         ];
     }

--- a/tests/unit_parser_test.php
+++ b/tests/unit_parser_test.php
@@ -1,0 +1,176 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace qtype_formulas;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/question/type/formulas/questiontype.php');
+
+use Exception;
+use qtype_formulas\local\unit_parser;
+
+/**
+ * Unit tests for the unit_parser class.
+ *
+ * @package    qtype_formulas
+ * @category   test
+ * @copyright  2025 Philipp Imhof
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \qtype_formulas\local\unit_parser
+ */
+final class unit_parser_test extends \advanced_testcase {
+
+    public function test_parse_unit_FIXME_REMOVE_WHEN_FINISHED() {
+        self::assertTrue(true);
+        return;
+        $input = '(m/s)^2';
+        $parser = new unit_parser($input);
+        var_dump($parser->get_statements()[0]);
+
+        echo $parser->get_legacy_unit_string();
+    }
+
+    /**
+     * Test parsing of unit inputs.
+     *
+     * @dataProvider provide_units
+     */
+    public function test_parse_unit($expected, $input) {
+        $e = null;
+        $error = '';
+        try {
+            new unit_parser($input);
+        } catch (Exception $e) {
+            $error = $e->getMessage();
+        }
+
+        // If we are expecting an error message, the exception object should not be null and
+        // the message should match, without checking row and column number.
+        if ($expected[0] === '!') {
+            self::assertNotNull($e);
+            self::assertStringEndsWith(substr($expected, 1), $error);
+        } else {
+            self::assertNull($e);
+        }
+    }
+
+    /**
+     * Test conversion of unit inputs to legacy input format.
+     *
+     * @dataProvider provide_units
+     */
+    public function test_get_legacy_unit_string($expected, $input) {
+        $e = null;
+        try {
+            $parser = new unit_parser($input);
+        } catch (Exception $e) {
+            $e->getMessage();
+        }
+
+        // If we are not expecting an error, check that the input has been translated as expected.
+        if ($expected[0] !== '!') {
+            self::assertEquals($expected, $parser->get_legacy_unit_string());
+        } else {
+            self::assertNotNull($e);
+        }
+    }
+
+    /**
+     * Data provider for the test functions. For simplicity, we use the same provider
+     * for valid and invalid expressions. In case of invalid expressions, we put an
+     * exclamation mark (!) at the start of the error message.
+     *
+     * @return array
+     */
+    public static function provide_units(): array {
+        return [
+            ['J/(m K)', 'J / m K'],
+            ['J/(m K)', 'J / m*K'],
+            ['J/(m K)', 'J / (m K)'],
+            ['J/(m K)', 'J / (m*K)'],
+            ['m kg/(s^2)', 'm kg/s^2'],
+            ['m kg/(s^2)', 'm kg / s^2'],
+            ['m kg/(s^2)', 'm*kg / s^2'],
+            ['m kg/(s^2)', 'm*(kg / s^2)'],
+            ['kg m/(s^2)', '(m/s^2)*kg'],
+            ['kg m/(s^2)', '(m/s^2) kg'],
+            ['m kg/(s^2)', '(m (kg / s^(2)))'],
+            ['m K kg/s', 'm (kg / s) K'],
+            ['s^(-1)', 's^-1'],
+            ['s^2', 's**2'],
+            ['s^(-1)', 's**-1'],
+            ['s^(-1)', 's^(-1)'],
+            ['s^(-1)', 's**(-1)'],
+            ['s^(-1)/(m^(-1))', 's**-1 / m**-1'],
+            ['m', 'm'],
+            ['m', '(m)'],
+            ['km', 'km'],
+            ['m^2', 'm^2'],
+            ['m^2', 'm^(2)'],
+            ['m^2', '(m^2)'],
+            ['m^2', 'm**2'],
+            ['m^2', '(m**2)'],
+            ['m^2', 'm**(2)'],
+            ['m^2', 'm ^ 2'],
+            ['m^2', 'm ^ (2)'],
+            ['m^2', 'm ** 2'],
+            ['m^2', 'm ** (2)'],
+            ['m^(-2)', 'm^-2'],
+            ['m^(-2)', '(m^-2)'],
+            ['m^(-2)', 'm^(-2)'],
+            ['m^(-2)', 'm ^ -2'],
+            ['m^(-2)', 'm ^ (-2)'],
+            ['m/s', 'm/s'],
+            ['m/s', '(m)/(s)'],
+            ['m/s', '(m/s)'],
+            ['m s^(-1)', 'm s^-1'],
+            ['m s^(-1)', 'm (s^-1)'],
+            ['m s^(-1)', 'm (s^(-1))'],
+            ['m s^(-1)', 'm s^(-1)'],
+            ['m/(s^(-1))', 'm / (s^(-1))'],
+            ['m/(s^(-1))', 'm / ((s^(-1)))'],
+            ['kg m/s', 'kg m/s'],
+            ['kg m/s', 'kg (m/s)'],
+            ['kg m/s', 'kg*(m/s)'],
+            ['kg m/s', 'kg*m/s'],
+            ['kg m/s', '(kg m)/s'],
+            ['kg m/s', '(kg*m)/s'],
+            ['kg m s^(-1)', 'kg m s^-1'],
+            ['kg m^2', 'kg m^2'],
+            ['kg m^2', 'kg m ^ 2'],
+            ['kg m s^(-1)', 'kg m s ^ - 1'],
+            ['!Unit already used: m', 'm kg / m'],
+            ['!Unexpected token: 1', 'm 1/s'],
+            ['!Unexpected token: 1', '1/s'],
+            ['!Unexpected token: 1', '1 m/s'],
+            ['!Unexpected token: 2', '2/s'],
+            ['!Unexpected token: 2.1', '2.1'],
+            ['!Unexpected token: ^', '^2'],
+            ['!Unexpected token: *', '*s'],
+            ['!Unexpected token: *', 'm* *kg'],
+            ['!Unexpected token: /', '/s'],
+            ['!Unexpected token: *', 'm*'],
+            ['!Unexpected token: /', 'm/'],
+            ['!Unexpected token: ^', 'm^'],
+            ['!Unexpected token: /', 'm^(/2)'],
+            ['!Unexpected token: +', 'm^+2'],
+            ["!Unexpected input: '@'", '@'],
+        ];
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_formulas';
-$plugin->version = 2025021402;
+$plugin->version = 2025021400;
 
 $plugin->cron = 0;
 $plugin->requires = 2022112800;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_formulas';
-$plugin->version = 2025021400;
+$plugin->version = 2025021402;
 
 $plugin->cron = 0;
 $plugin->requires = 2022112800;


### PR DESCRIPTION
Replacing the entire unit conversion code takes time. The aim of this PR is to write a compatibility layer that uses the new parsing system for analysis of unit expressions. We can use this to quickly validate student input (and teacher input in the edit form) and do proper MathJax rendering in quizzes. 

The code will convert the input into a string that can be passed to the legacy unit conversion code, allowing  to keep the old system in place for a while.