### PR TITLE
Fix layout for "There are other correct answers." checkbox

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -149,6 +149,13 @@ body#page-question-type-formulas .formulas_input_info_interpretation_incorrect {
     padding: 2px;
 }
 
+/* Form rows normally have 1rem of bottom margin. However, if the form field's ID is answer_xxx,
+   that margin will be forced to 0 for nicer rendering in the multichoice qtype's edit form. We
+   now have to force the margin again to get it back. */
+body#page-question-type-formulas div[id^="fitem_id_answer_"].mb-3 {
+    margin-bottom: 1rem !important;
+}
+
 /* RTL hacks */
 #page-question-type-formulas #id_varsrandom,
 #page-question-type-formulas #id_varsglobal {


### PR DESCRIPTION
Currently, the checkbox "There are other correct answers." is too close to the input field for model answers. This is due to some style tweaking done by core's multichoice question.

This PR "overrides the override" and brings back the normal layout.