### PR TITLE
Avoid creating duplicates when restoring older backups

### DIFF
--- a/backup/moodle2/restore_qtype_formulas_plugin.class.php
+++ b/backup/moodle2/restore_qtype_formulas_plugin.class.php
@@ -39,7 +39,7 @@ class restore_qtype_formulas_plugin extends restore_qtype_plugin {
         // section. For every question, we will have <formulas_answers></formulas_answers> to enclose
         // all parts. For each part, there will then be a <formulas_answer id="..."></formulas_answer>
         // section containing the various data fields, e. g. <placeholder> or <numbox> etc. These
-        // are the fields stored in the qtype_formulas_answers table, except for the partindex.
+        // are the fields stored in the qtype_formulas_answers table.
         $paths[] = new restore_path_element('formulas_answer', $this->get_pathfor('/formulas_answers/formulas_answer'));
 
         // Additionally, there will be <formulas id="..."></formulas> containing the custom data
@@ -187,8 +187,12 @@ class restore_qtype_formulas_plugin extends restore_qtype_plugin {
         $questiondata = parent::convert_backup_to_questiondata($backupdata);
 
         // As our parts are backed up in a separate XML key rather than just "answers", the parent
-        // function did not add them to the questiondata.
+        // function did not add them to the questiondata. Old backups may lack the "answernotunique"
+        // key, in which case we add it here with the default value.
         foreach ($backupdata['plugin_qtype_formulas_question']['formulas_answers']['formulas_answer'] as $answer) {
+            if (!key_exists('answernotunique', $answer)) {
+                $answer['answernotunique'] = '1';
+            }
             $questiondata->options->answers[] = (object) $answer;
         }
 
@@ -205,7 +209,9 @@ class restore_qtype_formulas_plugin extends restore_qtype_plugin {
     /**
      * Return a list of paths to fields to be removed from questiondata before creating an identity hash.
      * We have to remove the id and questionid property from all answers (parts) as well as the numparts
-     * field, because it is automatically calculated rather than stored in the database.
+     * field, because it is automatically calculated rather than stored in the database. We also remove
+     * the partindex, because (i) it might not be there in older backups and (ii) if a question only
+     * differs in the ordering of the parts, it does not make sense to duplicate it.
      *
      * @return array
      */

--- a/backup/moodle2/restore_qtype_formulas_plugin.class.php
+++ b/backup/moodle2/restore_qtype_formulas_plugin.class.php
@@ -188,10 +188,15 @@ class restore_qtype_formulas_plugin extends restore_qtype_plugin {
 
         // As our parts are backed up in a separate XML key rather than just "answers", the parent
         // function did not add them to the questiondata. Old backups may lack the "answernotunique"
-        // key, in which case we add it here with the default value.
-        foreach ($backupdata['plugin_qtype_formulas_question']['formulas_answers']['formulas_answer'] as $answer) {
+        // key, in which case we add it here with the default value. Also, backups might miss the
+        // "partindex" key. In that case, we add the key and order the parts according to their appearance
+        // in the file.
+        foreach ($backupdata['plugin_qtype_formulas_question']['formulas_answers']['formulas_answer'] as $i => $answer) {
             if (!key_exists('answernotunique', $answer)) {
                 $answer['answernotunique'] = '1';
+            }
+            if (!key_exists('partindex', $answer)) {
+                $answer['partindex'] = $i;
             }
             $questiondata->options->answers[] = (object) $answer;
         }
@@ -219,7 +224,6 @@ class restore_qtype_formulas_plugin extends restore_qtype_plugin {
         return [
             '/options/answers/id',
             '/options/answers/questionid',
-            '/options/answers/partindex',
             '/options/numparts',
         ];
     }

--- a/backup/moodle2/restore_qtype_formulas_plugin.class.php
+++ b/backup/moodle2/restore_qtype_formulas_plugin.class.php
@@ -213,6 +213,7 @@ class restore_qtype_formulas_plugin extends restore_qtype_plugin {
         return [
             '/options/answers/id',
             '/options/answers/questionid',
+            '/options/answers/partindex',
             '/options/numparts',
         ];
     }

--- a/tests/backup_restore_test.php
+++ b/tests/backup_restore_test.php
@@ -229,7 +229,7 @@ final class backup_restore_test extends \advanced_testcase {
         // Create a question category.
         $cat = $questiongenerator->create_question_category(['contextid' => $coursecontext->id]);
 
-        // Create 2 quizzes with 2 questions multichoice.
+        // Create 2 quizzes with 2 questions.
         $quiz1 = $this->create_test_quiz($course1);
         $question1 = $questiongenerator->create_question('formulas', $questionname, ['category' => $cat->id]);
         quiz_add_quiz_question($question1->id, $quiz1, 0);
@@ -275,6 +275,87 @@ final class backup_restore_test extends \advanced_testcase {
         $quiz2structure = \mod_quiz\question\bank\qbank_helper::get_question_structure($quiz2->instance, $quiz2->context);
         $this->assertEquals($quiz2structure[1]->questionid, $quiz2structure[1]->questionid);
         $this->assertEquals($quiz2structure[2]->questionid, $quiz2structure[2]->questionid);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public static function provide_xml_keys_to_remove(): array {
+        return [
+            ['answernotunique'],
+            ['partindex'],
+        ];
+    }
+
+    /**
+     * Restore a quiz with a question that does not have the partindex field set.
+     *
+     * @param string $which the XML key to remove from the backup
+     *
+     * @dataProvider provide_xml_keys_to_remove
+     */
+    public function test_restore_quiz_if_field_is_missing_in_backup(string $which): void {
+        global $CFG, $USER;
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        // The changes introduced while fixing MDL-83541 are only present in Moodle 4.4 and newer. It
+        // does not make sense to perform this test with older versions.
+        if ($CFG->branch < 404) {
+            $this->markTestSkipped(
+                'Not testing detection of duplicates while restoring in Moodle versions prior to 4.4.',
+            );
+        }
+
+        // Create a course and a user with editing teacher capabilities.
+        $generator = $this->getDataGenerator();
+        $course1 = $generator->create_course();
+        $teacher = $USER;
+        $generator->enrol_user($teacher->id, $course1->id, 'editingteacher');
+        $coursecontext = \context_course::instance($course1->id);
+        /** @var \core_question_generator $questiongenerator */
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+
+        // Create a question category.
+        $cat = $questiongenerator->create_question_category(['contextid' => $coursecontext->id]);
+
+        // Create a quiz with a simple Formulas question.
+        $quiz = $this->create_test_quiz($course1);
+        $question = $questiongenerator->create_question('formulas', 'testsinglenum', ['category' => $cat->id]);
+        quiz_add_quiz_question($question->id, $quiz, 0);
+
+        // Backup quiz1.
+        $bc = new backup_controller(backup::TYPE_1ACTIVITY, $quiz->cmid, backup::FORMAT_MOODLE,
+            backup::INTERACTIVE_NO, backup::MODE_IMPORT, $teacher->id);
+        $backupid = $bc->get_backupid();
+        $bc->execute_plan();
+        $bc->destroy();
+
+        // Delete requested entry from questions.xml file in the backup.
+        $xmlfile = $bc->get_plan()->get_basepath() . '/questions.xml';
+        $xml = file_get_contents($xmlfile);
+        $xml = preg_replace("=<$which>[^<]+</$which>=", '', $xml);
+        file_put_contents($xmlfile, $xml);
+
+        // Restore the (modified) backup into the same course.
+        $rc = new restore_controller($backupid, $course1->id, backup::INTERACTIVE_NO, backup::MODE_IMPORT,
+            $teacher->id, backup::TARGET_CURRENT_ADDING);
+        $rc->execute_precheck();
+        $rc->execute_plan();
+        $rc->destroy();
+
+        // Verify that the newly-restored quiz uses the same question as quiz1.
+        $modules = get_fast_modinfo($course1->id)->get_instances_of('quiz');
+        $this->assertCount(2, $modules);
+        $quizstructure = \mod_quiz\question\bank\qbank_helper::get_question_structure(
+            $quiz->id,
+            \context_module::instance($quiz->cmid),
+        );
+        $restoredquiz = end($modules);
+        $restoredquizstructure = \mod_quiz\question\bank\qbank_helper::get_question_structure($restoredquiz->instance, $restoredquiz->context);
+        $this->assertEquals($quizstructure[1]->questionid, $restoredquizstructure[1]->questionid);
     }
 
     /**
@@ -543,7 +624,7 @@ final class backup_restore_test extends \advanced_testcase {
         // Create a question category.
         $cat = $questiongenerator->create_question_category(['contextid' => $coursecontext->id]);
 
-        // Create 2 questions multichoice.
+        // Create 2 questions.
         $quiz1 = $this->create_test_quiz($course1);
         $question1 = $questiongenerator->create_question('formulas', $questionname, ['category' => $cat->id]);
         quiz_add_quiz_question($question1->id, $quiz1, 0);
@@ -658,7 +739,7 @@ final class backup_restore_test extends \advanced_testcase {
         // Create a question category.
         $cat = $questiongenerator->create_question_category(['contextid' => $coursecontext->id]);
 
-        // A quiz with 2 multichoice questions.
+        // A quiz with 2 questions.
         $quiz1 = $this->create_test_quiz($course1);
         $question1 = $questiongenerator->create_question('formulas', 'testsinglenum', ['category' => $cat->id]);
         quiz_add_quiz_question($question1->id, $quiz1, 0);

--- a/tests/backup_restore_test.php
+++ b/tests/backup_restore_test.php
@@ -321,9 +321,9 @@ final class backup_restore_test extends \advanced_testcase {
         // Create a question category.
         $cat = $questiongenerator->create_question_category(['contextid' => $coursecontext->id]);
 
-        // Create a quiz with a simple Formulas question.
+        // Create a quiz with a multipart Formulas question.
         $quiz = $this->create_test_quiz($course1);
-        $question = $questiongenerator->create_question('formulas', 'testsinglenum', ['category' => $cat->id]);
+        $question = $questiongenerator->create_question('formulas', 'testmethodsinparts', ['category' => $cat->id]);
         quiz_add_quiz_question($question->id, $quiz, 0);
 
         // Backup quiz1.
@@ -354,7 +354,10 @@ final class backup_restore_test extends \advanced_testcase {
             \context_module::instance($quiz->cmid),
         );
         $restoredquiz = end($modules);
-        $restoredquizstructure = \mod_quiz\question\bank\qbank_helper::get_question_structure($restoredquiz->instance, $restoredquiz->context);
+        $restoredquizstructure = \mod_quiz\question\bank\qbank_helper::get_question_structure(
+            $restoredquiz->instance,
+            $restoredquiz->context,
+        );
         $this->assertEquals($quizstructure[1]->questionid, $restoredquizstructure[1]->questionid);
     }
 


### PR DESCRIPTION
Fixes #195 

In earlier versions, the `partindex` field was not included in the backup. That was not a problem in the sense that this field only determines the order of the parts in the edit form and that order will be modified on-the-fly if teachers use part placeholders. (The parts will then be ordered according to their appearance in the main question text.)

However, the partindex was included in the hash calculation introduced in MDL-83541. Hence, when restoring an older backup, the hash of the restored question could not match the one of its counterpart in the DB where the `partindex` was included in the hash calculation.

This PR excludes `partindex` from hash calculation, because a question should (probably) not be duplicated simply due to the ordering of its parts. I am still thinking about this and might change it before the final merge.

At the same time, the PR takes care of even older backups that might lack the `answernotunique` field which was introduced in #105 for version 5.3.0.

Finally, a unit test has been added to make sure hash calculations work fine even with older backups.