### PR TITLE
Add option to shuffle options in multi-choice

### DIFF
--- a/question.php
+++ b/question.php
@@ -1019,7 +1019,9 @@ class qtype_formulas_part {
      * - {_u} for the unit box
      * - {_n} for an answer box, n must be an integer
      * - {_n:str} for radio buttons, str must be a variable name
+     * - {_n:str:MCS} for *shuffled* radio buttons, str must be a variable name
      * - {_n:str:MCE} for a drop down field, MCE must be verbatim
+     * - {_n:str:MCES} for a *shuffled* drop down field, MCE must be verbatim
      * Note: {_0:MCE} is valid and will lead to radio boxes based on the variable MCE.
      * Every answer box in the array will itself be an associative array with the
      * keys 'placeholder' (the entire placeholder), 'options' (the name of the variable containing
@@ -1033,7 +1035,7 @@ class qtype_formulas_part {
      */
     public static function scan_for_answer_boxes(string $text): array {
         // Match the text and store the matches.
-        preg_match_all('/\{(_u|_\d+)(:(_[A-Za-z]|[A-Za-z]\w*)(:(MCE))?)?\}/', $text, $matches);
+        preg_match_all('/\{(_u|_\d+)(:(_[A-Za-z]|[A-Za-z]\w*)(:(MCE|MCS|MCES))?)?\}/', $text, $matches);
 
         $boxes = [];
 
@@ -1047,13 +1049,14 @@ class qtype_formulas_part {
             // text is later needed to replace the placeholder by the input element.
             // With $matches[3], we can access the name of the variable containing the options for the radio
             // boxes or the drop down list.
-            // Finally, the array $matches[4] will contain ':MCE' in case this has been specified. Otherwise,
-            // there will be an empty string.
+            // Finally, the array $matches[4] will contain ':MCE', ':MCES' or ':MCS' in case this has been
+            // specified. Otherwise, there will be an empty string.
             // TODO: add option 'size' (for characters) or 'width' (for pixel width).
             $boxes[$match] = [
                 'placeholder' => $matches[0][$i],
                 'options' => $matches[3][$i],
-                'dropdown' => ($matches[4][$i] === ':MCE'),
+                'dropdown' => (substr($matches[4][$i], 0, 4) === ':MCE'),
+                'shuffle' => (substr($matches[4][$i], -1) === 'S'),
             ];
         }
         return $boxes;

--- a/renderer.php
+++ b/renderer.php
@@ -228,12 +228,13 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
      * @param int|string $answerindex index of the answer (starting at 0) or special value for combined/separate unit field
      * @param question_attempt $qa question attempt that will be displayed on the page
      * @param array $answeroptions array of strings containing the answer options to choose from
+     * @param bool $shuffle whether the options should be shuffled
      * @param question_display_options $displayoptions controls what should and should not be displayed
      * @param string $feedbackclass
      * @return string HTML fragment
      */
     protected function create_radio_mc_answer(qtype_formulas_part $part, $answerindex, question_attempt $qa,
-            array $answeroptions, question_display_options $displayoptions, string $feedbackclass = ''): string {
+            array $answeroptions, bool $shuffle, question_display_options $displayoptions, string $feedbackclass = ''): string {
         /** @var qype_formulas_question $question */
         $question = $qa->get_question();
 
@@ -258,6 +259,18 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
             'sr-only'
         );
         $output .= html_writer::end_tag('legend');
+
+        // If needed, shuffle the options while maintaining the keys.
+        if ($shuffle) {
+            $keys = array_keys($answeroptions);
+            shuffle($keys);
+
+            $shuffledoptions = [];
+            foreach ($keys as $key) {
+                $shuffledoptions[$key] = $answeroptions[$key];
+            }
+            $answeroptions = $shuffledoptions;
+        }
 
         // Iterate over all options.
         foreach ($answeroptions as $i => $optiontext) {
@@ -340,11 +353,12 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
      * @param int|string $answerindex index of the answer (starting at 0) or special value for combined/separate unit field
      * @param question_attempt $qa question attempt that will be displayed on the page
      * @param array $answeroptions array of strings containing the answer options to choose from
+     * @param bool $shuffle whether the options should be shuffled
      * @param question_display_options $displayoptions controls what should and should not be displayed
      * @return string HTML fragment
      */
     protected function create_dropdown_mc_answer(qtype_formulas_part $part, $answerindex, question_attempt $qa,
-            array $answeroptions, question_display_options $displayoptions): string {
+            array $answeroptions, bool $shuffle, question_display_options $displayoptions): string {
         /** @var qype_formulas_question $question */
         $question = $qa->get_question();
 
@@ -377,6 +391,19 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
                 $optiontext, $part->subqtextformat , $qa, 'qtype_formulas', 'answersubqtext', $part->id, false
             );
         }
+
+        // If needed, shuffle the options while maintaining the keys.
+        if ($shuffle) {
+            $keys = array_keys($entries);
+            shuffle($keys);
+
+            $shuffledentries = [];
+            foreach ($keys as $key) {
+                $shuffledentries[$key] = $entries[$key];
+            }
+            $entries = $shuffledentries;
+        }
+
         $output .= html_writer::select($entries, $inputname, $currentanswer, ['' => ''], $inputattributes);
         $output .= html_writer::end_tag('span');
 
@@ -592,10 +619,12 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
             if ($optiontexts === null) {
                 $inputfieldhtml = $this->create_input_box($part, $answerindex, $qa, $options, $sub->feedbackclass);
             } else if ($boxes[$placeholder]['dropdown']) {
-                $inputfieldhtml = $this->create_dropdown_mc_answer($part, $i, $qa, $optiontexts->value, $options);
+                $inputfieldhtml = $this->create_dropdown_mc_answer(
+                    $part, $i, $qa, $optiontexts->value, $boxes[$placeholder]['shuffle'], $options
+                );
             } else {
                 $inputfieldhtml = $this->create_radio_mc_answer(
-                    $part, $i, $qa, $optiontexts->value, $options, $sub->feedbackclass
+                    $part, $i, $qa, $optiontexts->value, $boxes[$placeholder]['shuffle'], $options, $sub->feedbackclass
                 );
             }
 

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -1006,36 +1006,64 @@ final class question_test extends \advanced_testcase {
             [[], '{_u }'],
             [[], '{_a}'],
             [[
-                '_0' => ['placeholder' => '{_0}', 'options' => '', 'dropdown' => false],
+                '_0' => ['placeholder' => '{_0}', 'options' => '', 'dropdown' => false, 'shuffle' => false],
             ], '{_0}'],
             [[
-                '_0' => ['placeholder' => '{_0}', 'options' => '', 'dropdown' => false],
+                '_0' => ['placeholder' => '{_0}', 'options' => '', 'dropdown' => false, 'shuffle' => false],
             ], '{_0} {_1:}'],
             [[
-                '_0' => ['placeholder' => '{_0:foo}', 'options' => 'foo', 'dropdown' => false],
+                '_0' => ['placeholder' => '{_0:foo}', 'options' => 'foo', 'dropdown' => false, 'shuffle' => false],
             ], '{_0:foo}'],
             [[
-                '_0' => ['placeholder' => '{_0:MCE}', 'options' => 'MCE', 'dropdown' => false],
+                '_0' => ['placeholder' => '{_0:foo:MCS}', 'options' => 'foo', 'dropdown' => false, 'shuffle' => true],
+            ], '{_0:foo:MCS}'],
+            [[
+                '_0' => ['placeholder' => '{_0:MCE}', 'options' => 'MCE', 'dropdown' => false, 'shuffle' => false],
             ], '{_0:MCE}'],
             [[
-                '_0' => ['placeholder' => '{_0:foo:MCE}', 'options' => 'foo', 'dropdown' => true],
+                '_0' => ['placeholder' => '{_0:MCS}', 'options' => 'MCS', 'dropdown' => false, 'shuffle' => false],
+            ], '{_0:MCS}'],
+            [[
+                '_0' => ['placeholder' => '{_0:MCES}', 'options' => 'MCES', 'dropdown' => false, 'shuffle' => false],
+            ], '{_0:MCES}'],
+            [[
+                '_0' => ['placeholder' => '{_0:foo:MCE}', 'options' => 'foo', 'dropdown' => true, 'shuffle' => false],
             ], '{_0:foo:MCE}'],
             [[
-                '_0' => ['placeholder' => '{_0}', 'options' => '', 'dropdown' => false],
-                '_u' => ['placeholder' => '{_u}', 'options' => '', 'dropdown' => false],
+                '_0' => ['placeholder' => '{_0:foo:MCES}', 'options' => 'foo', 'dropdown' => true, 'shuffle' => true],
+            ], '{_0:foo:MCES}'],
+            [[
+                '_0' => ['placeholder' => '{_0}', 'options' => '', 'dropdown' => false, 'shuffle' => false],
+                '_u' => ['placeholder' => '{_u}', 'options' => '', 'dropdown' => false, 'shuffle' => false],
             ], '{_0}{_u}'],
             [[
-                '_0' => ['placeholder' => '{_0:foo}', 'options' => 'foo', 'dropdown' => false],
-                '_u' => ['placeholder' => '{_u}', 'options' => '', 'dropdown' => false],
+                '_0' => ['placeholder' => '{_0:foo}', 'options' => 'foo', 'dropdown' => false, 'shuffle' => false],
+                '_u' => ['placeholder' => '{_u}', 'options' => '', 'dropdown' => false, 'shuffle' => false],
             ], '{_0:foo} {_u}'],
             [[
-                '_0' => ['placeholder' => '{_0:MCE}', 'options' => 'MCE', 'dropdown' => false],
-                '_u' => ['placeholder' => '{_u}', 'options' => '', 'dropdown' => false],
+                '_0' => ['placeholder' => '{_0:MCE}', 'options' => 'MCE', 'dropdown' => false, 'shuffle' => false],
+                '_u' => ['placeholder' => '{_u}', 'options' => '', 'dropdown' => false, 'shuffle' => false],
             ], '{_0:MCE} {_u}'],
             [[
-                '_0' => ['placeholder' => '{_0:foo:MCE}', 'options' => 'foo', 'dropdown' => true],
-                '_u' => ['placeholder' => '{_u}', 'options' => '', 'dropdown' => false],
+                '_0' => ['placeholder' => '{_0:MCS}', 'options' => 'MCS', 'dropdown' => false, 'shuffle' => false],
+                '_u' => ['placeholder' => '{_u}', 'options' => '', 'dropdown' => false, 'shuffle' => false],
+            ], '{_0:MCS} {_u}'],
+            [[
+                '_0' => ['placeholder' => '{_0:MCES}', 'options' => 'MCES', 'dropdown' => false, 'shuffle' => false],
+                '_u' => ['placeholder' => '{_u}', 'options' => '', 'dropdown' => false, 'shuffle' => false],
+            ], '{_0:MCES} {_u}'],
+            [[
+                '_0' => ['placeholder' => '{_0:foo:MCE}', 'options' => 'foo', 'dropdown' => true, 'shuffle' => false],
+                '_u' => ['placeholder' => '{_u}', 'options' => '', 'dropdown' => false, 'shuffle' => false],
             ], '{_0:foo:MCE} {_u}'],
+            [[
+                '_0' => ['placeholder' => '{_0:foo:MCES}', 'options' => 'foo', 'dropdown' => true, 'shuffle' => true],
+                '_u' => ['placeholder' => '{_u}', 'options' => '', 'dropdown' => false, 'shuffle' => false],
+            ], '{_0:foo:MCES} {_u}'],
+            [[
+                '_0' => ['placeholder' => '{_0:foo:MCS}', 'options' => 'foo', 'dropdown' => false, 'shuffle' => true],
+                '_u' => ['placeholder' => '{_u}', 'options' => '', 'dropdown' => false, 'shuffle' => false],
+            ], '{_0:foo:MCS} {_u}'],
         ];
     }
 
@@ -1044,7 +1072,7 @@ final class question_test extends \advanced_testcase {
      *
      * @param array $expected associative array, key: answer variable (e. g. _0 or _u),
      *      value: 'placeholder' => string (original text), 'options' => string (name of var containing the options),
-     *      'dropdown' => bool
+     *      'dropdown' => bool, 'shuffle' => bool
      * @param string $input simulated input
      *
      * @dataProvider provide_answer_box_texts
@@ -1066,6 +1094,11 @@ final class question_test extends \advanced_testcase {
             ['_0', '{_0:foo} {_0:bar}'],
             ['_0', '{_0:foo:MCE} {_0}'],
             ['_0', '{_0:foo:MCE} {_0:foo}'],
+            ['_0', '{_0:foo:MCS} {_0:foo}'],
+            ['_0', '{_0:foo:MCS} {_0:foo:MCE}'],
+            ['_0', '{_0:foo:MCES} {_0:foo}'],
+            ['_0', '{_0:foo:MCES} {_0:foo:MCE}'],
+            ['_0', '{_0:foo:MCES} {_0:foo:MCS}'],
             ['_u', '{_0}{_u} {_u}'],
         ];
     }

--- a/tests/renderer_test.php
+++ b/tests/renderer_test.php
@@ -341,6 +341,70 @@ final class renderer_test extends walkthrough_test_base {
         );
     }
 
+    public function test_render_shuffled_mc(): void {
+        // Create a single part multiple choice (radio) question. Activate shuffling of the options
+        // and disable numbering of the answers, as that makes it easier to test.
+        $q = $this->get_test_formulas_question('testmc');
+        $q->answernumbering = '';
+        $q->parts[0]->subqtext = '{_0:mychoices:MCS}';
+
+        $this->start_attempt_at_question($q, 'immediatefeedback', 1);
+
+        // Count how many times each option appears first. Re-render the question until all options have been
+        // on the first position at least once. In case something is off, stop after 100 tries at latest.
+        $countfirst = ['Dog' => 0, 'Cat' => 0, 'Bird' => 0, 'Fish' => 0];
+        $allwerefirst = false;
+        $safety = 0;
+        while (!$allwerefirst && $safety < 100) {
+            $this->render();
+            $fieldset = preg_replace('=^(.*)<fieldset[^>]+>(.+)</fieldset>(.*)$=', '\\2', $this->currentoutput);
+            $answers = str_replace('Answer', '', strip_tags($fieldset));
+
+            foreach ($countfirst as $option => &$count) {
+                if (strstr($answers, $option, true) === '') {
+                    $count++;
+                }
+                $allwerefirst = (array_product($countfirst) > 0);
+            }
+            $safety++;
+        }
+
+        // Make sure we're not here just because of the safety switch.
+        self::assertTrue($allwerefirst);
+    }
+
+    public function test_render_shuffled_mce(): void {
+        // Create a single part multiple choice (dropdown) question. Activate shuffling of the options
+        // and disable numbering of the answers, as that makes it easier to test.
+        $q = $this->get_test_formulas_question('testmce');
+        $q->answernumbering = '';
+        $q->parts[0]->subqtext = '{_0:mychoices:MCES}';
+
+        $this->start_attempt_at_question($q, 'immediatefeedback', 1);
+
+        // Count how many times each option appears first. Re-render the question until all options have been
+        // on the first position at least once. In case something is off, stop after 100 tries at latest.
+        $countfirst = ['Dog' => 0, 'Cat' => 0, 'Bird' => 0, 'Fish' => 0];
+        $allwerefirst = false;
+        $safety = 0;
+        while (!$allwerefirst && $safety < 100) {
+            $this->render();
+            $select = preg_replace('=^(.*)<select[^>]+>(.+)</select>(.*)$=', '\\2', $this->currentoutput);
+            $answers = strip_tags($select);
+
+            foreach ($countfirst as $option => &$count) {
+                if (strstr($answers, $option, true) === '') {
+                    $count++;
+                }
+                $allwerefirst = (array_product($countfirst) > 0);
+            }
+            $safety++;
+        }
+
+        // Make sure we're not here just because of the safety switch.
+        self::assertTrue($allwerefirst);
+    }
+
     public function test_render_mc_question(): void {
         // Create a single part multiple choice (radio) question.
         $q = $this->get_test_formulas_question('testmc');


### PR DESCRIPTION
Closes #147 

This PR adds to syntax options for placeholders, i. e. `MCS` and `MCES`, in order to simplify shuffling of answer options in multiple choice answer fields.

* `{_0:options:MCS}` will give a radio-button multi-choice answer with shuffling, so it's `{_0:options}` plus the shuffling
* `{_0:options:MCES}` will give a drow-down multi-choice answer with shuffling, so it's `{_0:options:MCE}` plus the shuffling

Please note that this is not a Fort Knox high security mechanism. The options are simply *displayed* in random order, but the underlying answer value is still the same. So two students comparing the source code of their quiz would still be able to find out which answers are the same.

The idea is to offer a simple way to have randomised display of options in order to discourage students to just look at their neighbour's screen.

Automated tests will follow.