### PR TITLE
Fix line break with drop-down

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -369,6 +369,7 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
         $inputattributes['name'] = $inputname;
         $inputattributes['value'] = $currentanswer;
         $inputattributes['id'] = $inputname;
+        $inputattributes['class'] = 'formulas-select';
 
         $label = $this->create_label_for_input(
             $this->generate_accessibility_label_text($answerindex, $part->numbox, $part->partindex, $question->numparts),

--- a/styles.css
+++ b/styles.css
@@ -115,6 +115,10 @@ div[id^='fitem_id_postunit_'] #qtype_formulas_mathjax_display {
     background: transparent;
 }
 
+.que .formulation .formulas-select {
+    display: inline-block;
+}
+
 /* Styles for the editing form. */
 body#page-question-type-formulas .formulas_correctness_show {
     display: inline;


### PR DESCRIPTION
Fixes #244 

Prior to Moodle 5.0, `<select>` form fields were formatted using the `custom-select` class which defined `display: inline-block;`.

With Moodle 5.0 and its upgrade to Bootstrap 5, the default class for a `<select>` form field is now `form-select` where the style defines `display: block;`.

This fix adds a custom class `formulas-select` to our selects which will override the display style to `inline-block` again. In order for our option to have precedence over the default one, we use `.que .formulation .formulas-select` as the selector, as more specific selectors have precedence over more general ones.