### PR TITLE
Allow changing of individual elements in lists that are initialised with fill() 

### DIFF
--- a/classes/local/functions.php
+++ b/classes/local/functions.php
@@ -692,7 +692,15 @@ class functions {
         if ($count < 1) {
             self::die('error_func_first_posint', 'fill()');
         }
-        return array_fill(0, $count, token::wrap($value));
+
+        // We cannot use array_fill() here, because it will create the token only once and
+        // populate the array with multiple references to the same instance. Therefore,
+        // it will not be possible to change just one element of a list later.
+        $result = [];
+        for ($i = 0; $i < $count; $i++) {
+            $result[] = token::wrap($value);
+        }
+        return $result;
     }
 
     /**

--- a/tests/evaluator_test.php
+++ b/tests/evaluator_test.php
@@ -733,6 +733,12 @@ final class evaluator_test extends \advanced_testcase {
                 ],
                 'a=4; A = fill(2,0); B= fill ( 3,"Hello"); C=fill(a,4);',
             ],
+            'change element of list that was initialised with fill()' => [
+                [
+                    'a' => new variable('a', [6, 5, 4], variable::LIST),
+                ],
+                'a=fill(3, 1); a[0] = 6; a[1] = 5; a[2] = 4;',
+            ],
             'assign with indirect fill()' => [
                 [
                     'a' => new variable('a', [1, 2, 3, 4], variable::LIST),


### PR DESCRIPTION
Fixes #251 

We must not use `array_fill()` in our `fill()` function, because it will create the token only once and then populate the array with multiple references to the same instance. 

This PR changes the function and uses a for loop.