### PR TITLE
Fix instantiation check if variables contain HTML

### DIFF
--- a/classes/external/instantiation.php
+++ b/classes/external/instantiation.php
@@ -297,7 +297,7 @@ class instantiation extends \external_api {
                         new \external_single_structure(
                             [
                                 'name' => new \external_value(PARAM_TEXT, 'variable name', VALUE_REQUIRED),
-                                'value' => new \external_value(PARAM_TEXT, 'value', VALUE_REQUIRED),
+                                'value' => new \external_value(PARAM_RAW, 'value', VALUE_REQUIRED),
                             ],
                             'description of each random variable',
                             VALUE_REQUIRED
@@ -309,7 +309,7 @@ class instantiation extends \external_api {
                         new \external_single_structure(
                             [
                                 'name' => new \external_value(PARAM_TEXT, 'variable name', VALUE_REQUIRED),
-                                'value' => new \external_value(PARAM_TEXT, 'value', VALUE_REQUIRED),
+                                'value' => new \external_value(PARAM_RAW, 'value', VALUE_REQUIRED),
                             ],
                             'description of each global variable',
                             VALUE_REQUIRED
@@ -322,7 +322,7 @@ class instantiation extends \external_api {
                             new \external_single_structure(
                                 [
                                     'name' => new \external_value(PARAM_TEXT, 'variable name', VALUE_REQUIRED),
-                                    'value' => new \external_value(PARAM_TEXT, 'value', VALUE_REQUIRED),
+                                    'value' => new \external_value(PARAM_RAW, 'value', VALUE_REQUIRED),
                                 ]
                             ),
                             'list of variables for the corresponding part',

--- a/tests/externallib_test.php
+++ b/tests/externallib_test.php
@@ -334,6 +334,19 @@ final class externallib_test extends \externallib_advanced_testcase {
                 ['status' => 'ok', 'data' => [[
                     'randomvars' => [],
                     'globalvars' => [
+                        ['name' => 's', 'value' => 'a<br>b'],
+                    ],
+                    'parts' => [[['name' => '_0', 'value' => '1']]],
+                ]]],
+                [
+                    'n' => 1, 'randomvars' => '', 'globalvars' => 's = join("<br>", "a", "b");',
+                    'localvars' => [''], 'answers' => ['1'],
+                ],
+            ],
+            [
+                ['status' => 'ok', 'data' => [[
+                    'randomvars' => [],
+                    'globalvars' => [
                         ['name' => 'a', 'value' => '1'],
                         ['name' => 'b', 'value' => '2'],
                         ['name' => 'c', 'value' => '0'],


### PR DESCRIPTION
Fixes #250 

Validation of return value must not use `PARAM_TEXT` for the content of variables, but `PARAM_RAW`, because otherwise no HTML tags are allowed.