### PR TITLE
Add option to be more lenient during import

### DIFF
--- a/lang/en/qtype_formulas.php
+++ b/lang/en/qtype_formulas.php
@@ -333,8 +333,8 @@ The basic one is the "Common SI units" rules that will convert standard units su
 say, km, m, cm and mm. This option has no effect if no unit has been used.';
 $string['settingallowdecimalcomma'] = 'Localised decimal separator';
 $string['settingallowdecimalcomma_desc'] = 'Allow all students to use the comma as decimal separator in answers.<br>If activated, numbers will be displayed according to the locale settings.';
-$string['settinglenientimport'] = 'Lenient import';
-$string['settinglenientimport_desc'] = 'When importing a question, do not check whether the given model answers will receive full mark.';
+$string['settinglenientimport'] = 'Lenient check on import';
+$string['settinglenientimport_desc'] = 'When importing a question, do not check whether the provided model answers would receive full marks. <br>Note: You should only activate this setting temporarily.';
 $string['settings_heading_general'] = 'General preferences';
 $string['settings_heading_general_desc'] = '';
 $string['settings_heading_width'] = 'Default widths';

--- a/lang/en/qtype_formulas.php
+++ b/lang/en/qtype_formulas.php
@@ -113,7 +113,6 @@ $string['error_bitwor_integer'] = 'Bitwise OR should only be used with integers.
 $string['error_bitwxor_integer'] = 'Bitwise XOR should only be used with integers.';
 $string['error_cannotusealgebraic'] = 'Algebraic variable \'{$a}\' cannot be used in this context.';
 $string['error_criterion_empty'] = 'The grading criterion must not be empty.';
-$string['error_damaged_question'] = 'Invalid data. The Formulas question might have been damaged, e. g. during a failed import or restore process.';
 $string['error_db_delete'] = 'Could not delete record from the database, table {$a}.';
 $string['error_db_missing_options'] = 'Formulas question ID {$a} was missing an options record. Using default.';
 $string['error_db_read'] = 'Could not read from to the database, table {$a}.';
@@ -334,6 +333,8 @@ The basic one is the "Common SI units" rules that will convert standard units su
 say, km, m, cm and mm. This option has no effect if no unit has been used.';
 $string['settingallowdecimalcomma'] = 'Localised decimal separator';
 $string['settingallowdecimalcomma_desc'] = 'Allow all students to use the comma as decimal separator in answers.<br>If activated, numbers will be displayed according to the locale settings.';
+$string['settinglenientimport'] = 'Lenient import';
+$string['settinglenientimport_desc'] = 'When importing a question, do not check whether the given model answers will receive full mark.';
 $string['settings_heading_general'] = 'General preferences';
 $string['settings_heading_general_desc'] = '';
 $string['settings_heading_width'] = 'Default widths';
@@ -394,6 +395,7 @@ $string['choiceyes'] = 'Yes';
 $string['error_algebraic_var'] = 'Syntax error of defining algebraic variable.';
 $string['error_answertype_mistmatch'] = 'Answer type mismatch: Numerical answer type requires number and algebraic answer type requires string';
 $string['error_criterion'] = 'The grading criterion must be evaluated to a single number.';
+$string['error_damaged_question'] = 'Invalid data. The Formulas question might have been damaged, e. g. during a failed import or restore process.';
 $string['error_eval_numerical'] = 'Some expressions cannot be evaluated numerically.';
 $string['error_fixed_range'] = 'Syntax error of a fixed range.';
 $string['error_forbid_char'] = 'Formula or expression contains forbidden characters or operators.';

--- a/questiontype.php
+++ b/questiontype.php
@@ -850,7 +850,7 @@ class qtype_formulas extends question_type {
 
             // The grading criterion must not be empty. Also, if there is no grading criterion, it does
             // not make sense to continue the validation.
-            if (empty(trim($data->correctness[$i])) && !is_numeric(trim($data->answer[$i]))) {
+            if (empty(trim($data->correctness[$i])) && !is_numeric(trim($data->correctness[$i]))) {
                 $errors["correctness[$i]"] = get_string('error_criterion_empty', 'qtype_formulas');
                 continue;
             }

--- a/settings.php
+++ b/settings.php
@@ -61,6 +61,7 @@ if ($ADMIN->fulltree) {
             1000 => new lang_string('algebraic_formula', 'qtype_formulas'),
         ]
     ));
+
     // Default correctness.
     $settings->add(new admin_setting_configtext(
         'qtype_formulas/defaultcorrectness',
@@ -68,6 +69,7 @@ if ($ADMIN->fulltree) {
         new lang_string('defaultcorrectness_desc', 'qtype_formulas'),
         '_relerr < 0.01'
     ));
+
     // Default answermark.
     $settings->add(new admin_setting_configtext(
         'qtype_formulas/defaultanswermark',
@@ -77,6 +79,7 @@ if ($ADMIN->fulltree) {
         PARAM_FLOAT,
         4
     ));
+
     // Default unit penalty.
     $settings->add(new admin_setting_configtext(
         'qtype_formulas/defaultunitpenalty',

--- a/settings.php
+++ b/settings.php
@@ -40,6 +40,14 @@ if ($ADMIN->fulltree) {
         0
     ));
 
+    // Whether we should omit the check the model answer's correctness during imports.
+    $settings->add(new admin_setting_configcheckbox(
+        'qtype_formulas/lenientimport',
+        new lang_string('settinglenientimport', 'qtype_formulas'),
+        new lang_string('settinglenientimport_desc', 'qtype_formulas'),
+        0
+    ));
+
     // Default answer type.
     $settings->add(new admin_setting_configselect(
         'qtype_formulas/defaultanswertype',

--- a/tests/fixtures/qtype_sample_formulas_invalid_grading_model_answer.xml
+++ b/tests/fixtures/qtype_sample_formulas_invalid_grading_model_answer.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<quiz>
+<!-- question: 410  -->
+  <question type="formulas">
+    <name>
+      <text>Formulas question 001</text>
+    </name>
+    <questiontext format="html">
+      <text><![CDATA[Question text]]></text>
+    </questiontext>
+    <generalfeedback format="html">
+      <text></text>
+    </generalfeedback>
+    <defaultgrade>2.0000000</defaultgrade>
+    <penalty>0.1000000</penalty>
+    <hidden>0</hidden>
+    <correctfeedback format="html">
+      <text></text>
+    </correctfeedback>
+    <partiallycorrectfeedback format="html">
+      <text></text>
+    </partiallycorrectfeedback>
+    <incorrectfeedback format="html">
+      <text></text>
+    </incorrectfeedback>
+<varsrandom><text></text>
+</varsrandom>
+<varsglobal><text></text>
+</varsglobal>
+<answers>
+ <partindex>
+  <text>0</text>
+ </partindex>
+ <placeholder>
+  <text></text>
+ </placeholder>
+ <answermark>
+  <text>2</text>
+ </answermark>
+ <answertype>
+  <text>0</text>
+ </answertype>
+ <numbox>
+  <text>1</text>
+ </numbox>
+ <vars1>
+  <text></text>
+ </vars1>
+ <answer>
+  <text>1</text>
+ </answer>
+ <vars2>
+  <text></text>
+ </vars2>
+ <correctness>
+  <text>0</text>
+ </correctness>
+ <unitpenalty>
+  <text>1</text>
+ </unitpenalty>
+ <postunit>
+  <text></text>
+ </postunit>
+ <ruleid>
+  <text>1</text>
+ </ruleid>
+ <otherrule>
+  <text></text>
+ </otherrule>
+ <subqtext format="html">
+<text></text>
+ </subqtext>
+ <feedback format="html">
+<text></text>
+ </feedback>
+</answers>
+  </question>
+
+</quiz>

--- a/tests/fixtures/qtype_sample_formulas_invalid_no_answer.xml
+++ b/tests/fixtures/qtype_sample_formulas_invalid_no_answer.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<quiz>
+<!-- question: 410  -->
+  <question type="formulas">
+    <name>
+      <text>Formulas question 001</text>
+    </name>
+    <questiontext format="html">
+      <text><![CDATA[Question text]]></text>
+    </questiontext>
+    <generalfeedback format="html">
+      <text></text>
+    </generalfeedback>
+    <defaultgrade>2.0000000</defaultgrade>
+    <penalty>0.1000000</penalty>
+    <hidden>0</hidden>
+    <correctfeedback format="html">
+      <text></text>
+    </correctfeedback>
+    <partiallycorrectfeedback format="html">
+      <text></text>
+    </partiallycorrectfeedback>
+    <incorrectfeedback format="html">
+      <text></text>
+    </incorrectfeedback>
+<varsrandom><text></text>
+</varsrandom>
+<varsglobal><text></text>
+</varsglobal>
+<answers>
+ <partindex>
+  <text>0</text>
+ </partindex>
+ <placeholder>
+  <text></text>
+ </placeholder>
+ <answermark>
+  <text>2</text>
+ </answermark>
+ <answertype>
+  <text>0</text>
+ </answertype>
+ <numbox>
+  <text>1</text>
+ </numbox>
+ <vars1>
+  <text></text>
+ </vars1>
+ <answer>
+  <text></text>
+ </answer>
+ <vars2>
+  <text></text>
+ </vars2>
+ <correctness>
+  <text><![CDATA[_relerr < 0.01]]></text>
+ </correctness>
+ <unitpenalty>
+  <text>1</text>
+ </unitpenalty>
+ <postunit>
+  <text></text>
+ </postunit>
+ <ruleid>
+  <text>1</text>
+ </ruleid>
+ <otherrule>
+  <text></text>
+ </otherrule>
+ <subqtext format="html">
+<text></text>
+ </subqtext>
+ <feedback format="html">
+<text></text>
+ </feedback>
+</answers>
+  </question>
+
+</quiz>

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -464,6 +464,12 @@ final class questiontype_test extends \advanced_testcase {
                 ],
             ],
             [
+                ['correctness[0]' => get_string('error_grading_not_one', 'qtype_formulas', 0)],
+                [
+                    'correctness' => [0 => '0'],
+                ],
+            ],
+            [
                 ['correctness[0]' => get_string('error_grading_single_expression', 'qtype_formulas', 2)],
                 [
                     'correctness' => [0 => 'a=1; b=2'],

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -995,7 +995,7 @@ final class questiontype_test extends \advanced_testcase {
     }
 
     /**
-     * Data provider.
+     * Data provider. For invalid imports, we introduce the expected error message by adding an exclamation mark.
      *
      * @return array
      */
@@ -1008,16 +1008,26 @@ final class questiontype_test extends \advanced_testcase {
                 $CFG->dirroot . '/question/type/formulas/tests/fixtures/qtype_sample_formulas_5.3.0.xml',
             ],
             [
+                '!At least one answer is required.',
+                $CFG->dirroot . '/question/type/formulas/tests/fixtures/qtype_sample_formulas_invalid_no_answer.xml',
+            ],
+            [
+                '!The grading criterion should evaluate to 1 for correct answers.',
+                $CFG->dirroot . '/question/type/formulas/tests/fixtures/qtype_sample_formulas_invalid_grading_model_answer.xml',
+            ],
+            [
                 'For a minimal question, you must define a subquestion with (1) mark, (2) answer, (3) grading criteria',
                 $CFG->dirroot . '/question/type/formulas/tests/fixtures/qtype_sample_formulas_5.2.0.xml',
             ],
         ];
     }
+
     /**
      * Test importing a question from a prior XML export.
      *
-     * @param string $expected expected output after XML import
+     * @param string $expected expected output after XML import (starting with ! for expected errors)
      * @param string $filename path of fixture file to be used
+     *
      * @dataProvider provide_import_filenames
      */
     public function test_import_from_xml($expected, $filename): void {
@@ -1053,7 +1063,89 @@ final class questiontype_test extends \advanced_testcase {
 
         // Import our XML file.
         self::assertTrue($qformat->importpreprocess());
-        self::assertTrue($qformat->importprocess());
+        if ($expected[0] !== '!') {
+            self::assertTrue($qformat->importprocess());
+        } else {
+            $expected = substr($expected, 1);
+            self::assertFalse($qformat->importprocess());
+        }
+        self::assertTrue($qformat->importpostprocess());
+
+        // Importing generates output. Make sure the tests expects that.
+        $this->expectOutputRegex('/\+\+ Importing 1 questions from file \+\+.*' . preg_quote($expected, '/') . '/s');
+    }
+
+    /**
+     * Data provider. For invalid imports, we introduce the expected error message by adding an exclamation mark.
+     *
+     * @return array
+     */
+    public static function provide_import_filenames_for_lenient_import(): array {
+        global $CFG;
+
+        return [
+            [
+                '!At least one answer is required.',
+                $CFG->dirroot . '/question/type/formulas/tests/fixtures/qtype_sample_formulas_invalid_no_answer.xml',
+            ],
+            [
+                'Question text',
+                $CFG->dirroot . '/question/type/formulas/tests/fixtures/qtype_sample_formulas_invalid_grading_model_answer.xml',
+            ],
+        ];
+    }
+
+    /**
+     * Test lenient check of imported question.
+     *
+     * @param string $expected expected output after XML import (starting with ! for expected errors)
+     * @param string $filename path of fixture file to be used
+     *
+     * @dataProvider provide_import_filenames_for_lenient_import
+     */
+    public function test_lenient_import_from_xml($expected, $filename): void {
+        global $CFG;
+
+        // Login as admin user.
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        // Create a course and a question category.
+        $course = $this->getDataGenerator()->create_course();
+        $context = context_system::instance();
+        /** @var \core_question_generator $questiongenerator */
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+        $category = $questiongenerator->create_question_category(['contextid' => $context->id]);
+
+        // Prepare the XML format class.
+        require_once($CFG->dirroot . '/question/format/xml/format.php');
+        $qformat = new \qformat_xml();
+        $qformat->setCategory($category);
+        if (class_exists('\core_question\local\bank\question_edit_contexts')) {
+            $contexts = new \core_question\local\bank\question_edit_contexts($context);
+        } else {
+            $contexts = new \question_edit_contexts($context);
+        }
+        $qformat->setContexts($contexts);
+        $qformat->setCourse($course);
+        $qformat->setFilename($filename);
+        $qformat->setMatchgrades(false);
+        $qformat->setCatfromfile(false);
+        $qformat->setContextfromfile(false);
+        $qformat->setStoponerror(true);
+
+        // Activate lenient import.
+        set_config('lenientimport', 1, 'qtype_formulas');
+        self::assertEquals('1', get_config('qtype_formulas', 'lenientimport'));
+
+        // Import our XML file.
+        self::assertTrue($qformat->importpreprocess());
+        if ($expected[0] !== '!') {
+            self::assertTrue($qformat->importprocess());
+        } else {
+            $expected = substr($expected, 1);
+            self::assertFalse($qformat->importprocess());
+        }
         self::assertTrue($qformat->importpostprocess());
 
         // Importing generates output. Make sure the tests expects that.


### PR DESCRIPTION
Since version 6.0, the Formulas question plugin checks whether the model answers entered by the teacher will lead to full marks. If this is not the case, the question cannot be saved, as this is most likely a mistake. Teachers might have a bunch of old questions around that were created before the introduction of this check. The questions might thus have that problem and it will make the import process fail. 

This PR makes it possible to omit that one specific check during imports (and during imports only!).

While I still think the check is useful and necessary, I also think it should be possible to -- at least temporarily -- deactivate it in order to move forward with a bulk import of questions and, hopefully, address the issue with those questions later.

Also, the PR changes two other things:

* Better error reporting when import fails. Instead of the generic and rather useless error message "Invalid data. The Formulas question might have been damaged, e. g. during a failed import or restore process." we now show the error message returned from the various validations functions in order for the teacher to know what is actually wrong with the question they are trying to import.
* Don't consider "0" as an empty grading criterion. It will still trigger an error, because it does not evaluate to 1 (or more) for the model answers, but saying "The grading criterion must not be empty." is misleading.