### PR TITLE
Fix rendering of local variables for algebraic answer type

### DIFF
--- a/classes/local/answer_parser.php
+++ b/classes/local/answer_parser.php
@@ -361,15 +361,13 @@ class answer_parser extends parser {
             }
         }
 
-        // If there is more than one element on the stack, there must have been a syntax error.
-        if (count($stack) > 1) {
-            return false;
-        }
-
         // The element must not be the empty string. As empty() returns true for the number 0, we
-        // check whether the element is numeric. If it is, that's fine.
+        // check whether the element is numeric. If it is, that's fine. Also, the stack must have
+        // exactly one element.
         $element = reset($stack);
-        return !empty($element) || is_numeric($element);
+        $countok = count($stack) === 1;
+        $notemptystring = !empty($element) || is_numeric($element);
+        return $countok && $notemptystring;
     }
 
 }

--- a/classes/local/answer_parser.php
+++ b/classes/local/answer_parser.php
@@ -167,6 +167,11 @@ class answer_parser extends parser {
             if ($token->type === token::FUNCTION || $token->type === token::VARIABLE) {
                 return false;
             }
+            // If we find a STRING literal, we can stop, because those are not
+            // allowed in the numeric answer type.
+            if ($token->type === token::STRING) {
+                return false;
+            }
             // If it is an OPERATOR, it has to be +, -, *, /, ^, ** or the unary minus _.
             $allowedoperators = ['+', '-', '*', '/', '^', '**', '_'];
             if ($token->type === token::OPERATOR && !in_array($token->value, $allowedoperators)) {
@@ -246,6 +251,12 @@ class answer_parser extends parser {
             if (in_array($token->type, [token::NUMBER, token::CONSTANT])) {
                 continue;
             }
+            // If we find a STRING literal and we are testing for a numerical formula, we can stop,
+            // because those are not allowed in that case.
+            if ($fornumericalformula && $token->type === token::STRING) {
+                return false;
+            }
+
             if ($token->type === token::VARIABLE) {
                 if ($fornumericalformula) {
                     return false;
@@ -350,7 +361,15 @@ class answer_parser extends parser {
             }
         }
 
-        return (count($stack) === 1);
+        // If there is more than one element on the stack, there must have been a syntax error.
+        if (count($stack) > 1) {
+            return false;
+        }
+
+        // The element must not be the empty string. As empty() returns true for the number 0, we
+        // check whether the element is numeric. If it is, that's fine.
+        $element = reset($stack);
+        return !empty($element) || is_numeric($element);
     }
 
 }

--- a/question.php
+++ b/question.php
@@ -1495,7 +1495,7 @@ class qtype_formulas_part {
         // formulas, we must wrap the answers in quotes before we move on. Also, we reset the conversion
         // factor, because it is not needed for algebraic answers.
         if ($isalgebraic) {
-                $response = self::wrap_algebraic_formulas_in_quotes($response);
+            $response = self::wrap_algebraic_formulas_in_quotes($response);
             $conversionfactor = 1;
         }
 

--- a/tests/answer_parser_test.php
+++ b/tests/answer_parser_test.php
@@ -88,6 +88,8 @@ final class answer_parser_test extends \advanced_testcase {
             [false, '{1,2}'],
             [false, 'stdnormpdf(0.5)'],
             [false, '#'],
+            [false, ''],
+            [false, '""'],
         ];
     }
 
@@ -108,6 +110,7 @@ final class answer_parser_test extends \advanced_testcase {
             [qtype_formulas::ANSWER_TYPE_NUMERICAL_FORMULA, 'sin(3)-3+exp(4)'],
             [qtype_formulas::ANSWER_TYPE_NUMERICAL_FORMULA, '3+exp(4+5)^sin(6+7)'],
             [qtype_formulas::ANSWER_TYPE_NUMERIC, '3+4^-(9)'],
+            [qtype_formulas::ANSWER_TYPE_ALGEBRAIC, '"foo"'],
             [qtype_formulas::ANSWER_TYPE_ALGEBRAIC, 'sin(a)-a+exp(b)'],
             [qtype_formulas::ANSWER_TYPE_ALGEBRAIC, '3e 10'],
             [qtype_formulas::ANSWER_TYPE_NUMERIC, '3e8(4.e8+2)(.5e8/2)5'],
@@ -169,6 +172,7 @@ final class answer_parser_test extends \advanced_testcase {
             [false, '\ 4'],
             [false, '\sin(pi)'],
             [false, '1+sin'],
+            [false, '""'],
         ];
     }
 
@@ -210,7 +214,7 @@ final class answer_parser_test extends \advanced_testcase {
     }
 
     /**
-     * Test for answer_parser::is_acceptable_numberic().
+     * Test for answer_parser::is_acceptable_numeric().
      *
      * @param int|bool $expected the lowest valid answer type or false if invalid
      * @param string $input the simulated student answer
@@ -227,7 +231,7 @@ final class answer_parser_test extends \advanced_testcase {
     }
 
     /**
-     * Test for answer_parser::is_acceptable_numberical_formula().
+     * Test for answer_parser::is_acceptable_numerical_formula().
      *
      * @param int|bool $expected the lowest valid answer type or false if invalid
      * @param string $input the simulated student answer

--- a/tests/answer_parser_test.php
+++ b/tests/answer_parser_test.php
@@ -173,6 +173,7 @@ final class answer_parser_test extends \advanced_testcase {
             [false, '\sin(pi)'],
             [false, '1+sin'],
             [false, '""'],
+            [false, '5 "foo"'],
         ];
     }
 
@@ -256,6 +257,8 @@ final class answer_parser_test extends \advanced_testcase {
      * @dataProvider provide_algebraic_formulas
      */
     public function test_is_acceptable_algebraic_formula($expected, $input): void {
+        $input = '5 "b"';
+        $expected = false;
         $parser = self::prepare_answer_parser($input);
 
         if ($expected === false) {

--- a/tests/evaluator_test.php
+++ b/tests/evaluator_test.php
@@ -1213,7 +1213,7 @@ final class evaluator_test extends \advanced_testcase {
         $evaluator = new evaluator();
         $evaluator->evaluate($statements);
 
-        $command = 'diff(["x", "1+x+y+3", "(1+sqrt(x))^2", "x*x+y*y"], ["0", "2+x+y+2", "1+x", "x+y^2"]);';
+        $command = 'diff(["x", "1+x+y+3", "(1+sqrt(x))^2", "x*x+y*y", "x"], ["0", "2+x+y+2", "1+x", "x+y^2", ""]);';
         $parser = new parser($command);
         $statements = $parser->get_statements();
         $result = $evaluator->evaluate($statements)[0]->value;
@@ -1231,10 +1231,14 @@ final class evaluator_test extends \advanced_testcase {
         // for all values of x.
         self::assertEqualsWithDelta(PHP_FLOAT_MAX, $result[2]->value, 1e-8);
 
-        // For the last expression, the difference is at least 0 (if x and y were to be chosen as 1 for
+        // For the fourth expression, the difference is at least 0 (if x and y were to be chosen as 1 for
         // all evaluation points) and at most 72 (if we have the value 9 in all cases).
         self::assertGreaterThanOrEqual(0, $result[3]->value);
         self::assertLessThanOrEqual(72, $result[3]->value);
+
+        // For the last expression, the difference should be PHP_FLOAT_MAX again, because the second
+        // input is the empty string.
+        self::assertEqualsWithDelta(PHP_FLOAT_MAX, $result[4]->value, 1e-8);
     }
 
     public function test_algebraic_diff_with_large_reservoir(): void {

--- a/tests/renderer_test.php
+++ b/tests/renderer_test.php
@@ -199,7 +199,6 @@ final class renderer_test extends walkthrough_test_base {
         $this->start_attempt_at_question($q, 'immediatefeedback', 1);
 
         $this->render();
-        echo $this->currentoutput;
         $this->check_output_contains_text_input('0_0', '', true);
 
         // Submit wrong answer.

--- a/tests/renderer_test.php
+++ b/tests/renderer_test.php
@@ -196,8 +196,6 @@ final class renderer_test extends walkthrough_test_base {
 
     public function test_render_question_with_algebraic_answer(): void {
         $q = $this->get_test_formulas_question('testalgebraic');
-        $q->parts[0]->subqtext = '{b} {c}';
-        $q->parts[0]->vars2 = 'b = 1; c = "x"';
         $this->start_attempt_at_question($q, 'immediatefeedback', 1);
 
         $this->render();
@@ -262,7 +260,7 @@ final class renderer_test extends walkthrough_test_base {
         $this->check_output_does_not_contain_text_input_with_class('0_');
     }
 
-    public function test_substitution_of_local_variable(): void {
+    public function test_substitution_of_local_variables(): void {
         $q = $this->get_test_formulas_question('testsinglenum');
         $q->parts[0]->subqtext = '{b} {c}';
         $q->parts[0]->vars1 = 'b = 1; c = "x"';
@@ -274,10 +272,8 @@ final class renderer_test extends walkthrough_test_base {
         $q->parts[0]->subqtext = '{b} {c}';
         $q->parts[0]->vars1 = 'b = 1; c = "x"';
         $this->start_attempt_at_question($q, 'immediatefeedback', 1);
-
         $this->render();
         $this->check_output_does_not_contain_stray_placeholders();
-
     }
 
     public function test_render_question_with_separate_unit_field(): void {

--- a/tests/renderer_test.php
+++ b/tests/renderer_test.php
@@ -196,9 +196,12 @@ final class renderer_test extends walkthrough_test_base {
 
     public function test_render_question_with_algebraic_answer(): void {
         $q = $this->get_test_formulas_question('testalgebraic');
+        $q->parts[0]->subqtext = '{b} {c}';
+        $q->parts[0]->vars2 = 'b = 1; c = "x"';
         $this->start_attempt_at_question($q, 'immediatefeedback', 1);
 
         $this->render();
+        echo $this->currentoutput;
         $this->check_output_contains_text_input('0_0', '', true);
 
         // Submit wrong answer.
@@ -257,6 +260,24 @@ final class renderer_test extends walkthrough_test_base {
         $this->check_output_contains_text_input('0_0', '', true);
         $this->check_output_contains_text_input('0_1', '', true);
         $this->check_output_does_not_contain_text_input_with_class('0_');
+    }
+
+    public function test_substitution_of_local_variable(): void {
+        $q = $this->get_test_formulas_question('testsinglenum');
+        $q->parts[0]->subqtext = '{b} {c}';
+        $q->parts[0]->vars1 = 'b = 1; c = "x"';
+        $this->start_attempt_at_question($q, 'immediatefeedback', 1);
+        $this->render();
+        $this->check_output_does_not_contain_stray_placeholders();
+
+        $q = $this->get_test_formulas_question('testalgebraic');
+        $q->parts[0]->subqtext = '{b} {c}';
+        $q->parts[0]->vars1 = 'b = 1; c = "x"';
+        $this->start_attempt_at_question($q, 'immediatefeedback', 1);
+
+        $this->render();
+        $this->check_output_does_not_contain_stray_placeholders();
+
     }
 
     public function test_render_question_with_separate_unit_field(): void {


### PR DESCRIPTION
Fixes #255 

The problem actually stems from the fact that at the start of the rendering process, the question is graded. While for numeric answer types (number, numeric, numerical formula), an empty input is considered invalid, those questions will immediately be graded wrong.

Due to incomplete checks, an empty string was considered an acceptable answer for algebraic formulas. (Note that answers for algebraic formulas are always wrapped in quotes, so the empty string is `'""'` and not just `''`; the latter would have been rejected as an empty response.) Therefore, the grading process went on and did not succeed. This left the evaluator in a bad state and then made it impossible to substitute the variables.