### PR TITLE
Disallow quotes and strings in student answers

### DIFF
--- a/classes/external/answervalidation.php
+++ b/classes/external/answervalidation.php
@@ -100,7 +100,9 @@ class answervalidation extends \external_api {
             $parser = new answer_parser($number);
             // As we are in a try-catch block anyway, we can just throw an Exception if the answer
             // is not acceptable.
-            if (!$parser->is_acceptable_for_answertype($answertype)) {
+            $isacceptable = $parser->is_acceptable_for_answertype($answertype);
+            $containsquote = preg_match('/[\'"]/', $number);
+            if (!$isacceptable || $containsquote) {
                 $answertypestrings = [
                     qtype_formulas::ANSWER_TYPE_NUMBER => 'number',
                     qtype_formulas::ANSWER_TYPE_NUMERIC => 'numeric',

--- a/question.php
+++ b/question.php
@@ -1500,7 +1500,7 @@ class qtype_formulas_part {
             try {
                 $response = self::wrap_algebraic_formulas_in_quotes($response);
             } catch (Throwable $t) {
-                // TODO: convert to non-capturing catch
+                // TODO: convert to non-capturing catch.
                 return ['answer' => 0, 'unit' => $unitcorrect];
             }
             $conversionfactor = 1;

--- a/question.php
+++ b/question.php
@@ -1335,10 +1335,12 @@ class qtype_formulas_part {
      */
     private static function wrap_algebraic_formulas_in_quotes(array $formulas): array {
         foreach ($formulas as &$formula) {
-            // If the formula is aready wrapped in quotes (e. g. after an earlier call to this
-            // function), there is nothing to do.
+            // If the formula is aready wrapped in quotes, we throw an Exception, because that
+            // should not happen. It will happen, if the student puts quotes around their response, but
+            // we want that to be graded wrong. The exception will be caught and dealt with upstream,
+            // so we do not need to be more precise.
             if (preg_match('/^\"[^\"]*\"$/', $formula)) {
-                continue;
+                throw new Exception();
             }
 
             $formula = '"' . $formula . '"';
@@ -1495,7 +1497,12 @@ class qtype_formulas_part {
         // formulas, we must wrap the answers in quotes before we move on. Also, we reset the conversion
         // factor, because it is not needed for algebraic answers.
         if ($isalgebraic) {
-            $response = self::wrap_algebraic_formulas_in_quotes($response);
+            try {
+                $response = self::wrap_algebraic_formulas_in_quotes($response);
+            } catch (Throwable $t) {
+                // TODO: convert to non-capturing catch
+                return ['answer' => 0, 'unit' => $unitcorrect];
+            }
             $conversionfactor = 1;
         }
 

--- a/tests/answer_parser_test.php
+++ b/tests/answer_parser_test.php
@@ -90,6 +90,7 @@ final class answer_parser_test extends \advanced_testcase {
             [false, '#'],
             [false, ''],
             [false, '""'],
+            [false, '"foo"'],
         ];
     }
 
@@ -110,7 +111,6 @@ final class answer_parser_test extends \advanced_testcase {
             [qtype_formulas::ANSWER_TYPE_NUMERICAL_FORMULA, 'sin(3)-3+exp(4)'],
             [qtype_formulas::ANSWER_TYPE_NUMERICAL_FORMULA, '3+exp(4+5)^sin(6+7)'],
             [qtype_formulas::ANSWER_TYPE_NUMERIC, '3+4^-(9)'],
-            [qtype_formulas::ANSWER_TYPE_ALGEBRAIC, '"foo"'],
             [qtype_formulas::ANSWER_TYPE_ALGEBRAIC, 'sin(a)-a+exp(b)'],
             [qtype_formulas::ANSWER_TYPE_ALGEBRAIC, '3e 10'],
             [qtype_formulas::ANSWER_TYPE_NUMERIC, '3e8(4.e8+2)(.5e8/2)5'],
@@ -173,6 +173,7 @@ final class answer_parser_test extends \advanced_testcase {
             [false, '\sin(pi)'],
             [false, '1+sin'],
             [false, '""'],
+            [false, '"foo"'],
             [false, '5 "foo"'],
         ];
     }

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -1445,11 +1445,11 @@ final class question_test extends \advanced_testcase {
         return [
             [['""'], ['']],
             [['"a"'], ['a']],
-            [['"a"'], ['"a"']],
+            ['!', ['"a"']],
             [['"1"', '"2"'], ['1', '2']],
             [['""', '""'], ['', '']],
-            [['""', '""'], ['""', '""']],
-            [['"1"', '"x"'], ['"1"', '"x"']],
+            ['!', ['""', '""']],
+            ['!', ['"1"', '"x"']],
         ];
     }
 
@@ -1465,7 +1465,17 @@ final class question_test extends \advanced_testcase {
         $func = new \ReflectionMethod(qtype_formulas_part::class, 'wrap_algebraic_formulas_in_quotes');
         $func->setAccessible(true);
 
-        $wrapped = $func->invoke(null, $input);
+        $error = false;
+        try {
+            $wrapped = $func->invoke(null, $input);
+        } catch (Exception $e) {
+            $error = true;
+        }
+
+        if ($expected === '!') {
+            self::assertTrue($error);
+            return;
+        }
 
         foreach ($expected as $i => $exp) {
             self::assertEquals($exp, $wrapped[$i]);

--- a/tests/renderer_test.php
+++ b/tests/renderer_test.php
@@ -213,6 +213,19 @@ final class renderer_test extends walkthrough_test_base {
         $this->check_output_contains_lang_string('correctansweris', 'qtype_formulas', '5 * x^2');
         $this->check_output_does_not_contain('a*x^2');
 
+        // Submit correct answer in quotes, which will be graded wrong.
+        $this->start_attempt_at_question($q, 'immediatefeedback', 1);
+        $this->process_submission(['0_0' => '"5x^2"', '-submit' => 1]);
+        $this->check_current_state(question_state::$gradedwrong);
+        $this->check_current_mark(0);
+        $this->check_current_output(
+                $this->get_contains_mark_summary(0),
+        );
+        $this->render();
+        $this->check_output_contains_text_input('0_0', '"5x^2"', false);
+        $this->check_output_contains_lang_string('correctansweris', 'qtype_formulas', '5 * x^2');
+        $this->check_output_does_not_contain('a*x^2');
+
         // Submit right answer.
         $this->start_attempt_at_question($q, 'immediatefeedback', 1);
         $this->process_submission(['0_0' => '5*x^2', '-submit' => 1]);


### PR DESCRIPTION
While dealing with #256, I realised that handling of quotes in student answers is not ideal. There are two things:

- Student responses should not contain strings, so answer validation should show a warning whenever there are single or double quotes in a response.
- If the correct answer is `x` and the student enters `"x"`, it should be graded wrong. This is not the case at the moment, because, internally, algebraic formulas are represented as strings. Student responses are wrapped in quotes automatically and if quotes are already there, this is silently ignored, but should throw an error instead.