### PR TITLE
Allow :MC suffix for radio-box multi-choice answer

### DIFF
--- a/question.php
+++ b/question.php
@@ -236,7 +236,7 @@ class qtype_formulas_question extends question_graded_automatically_with_countba
 
         // For the question summary, it seems useful to simplify the answer box placeholders.
         $summary = preg_replace(
-            '/\{(_u|_\d+)(:(_[A-Za-z]|[A-Za-z]\w*)(:(MCE|MCES|MCS))?)?((\|[\w =#]*)*)\}/',
+            '/\{(_u|_\d+)(:(_[A-Za-z]|[A-Za-z]\w*)(:(MC|MCE|MCES|MCS))?)?((\|[\w =#]*)*)\}/',
             '{\1}',
             $summary,
         );
@@ -1026,7 +1026,7 @@ class qtype_formulas_part {
      * Answer box placeholders have one of the following forms:
      * - {_u} for the unit box
      * - {_n} for an answer box, n must be an integer
-     * - {_n:str} for radio buttons, str must be a variable name
+     * - {_n:str} or {_n:str:MC} for radio buttons, str must be a variable name
      * - {_n:str:MCS} for *shuffled* radio buttons, str must be a variable name
      * - {_n:str:MCE} for a drop down field, MCE must be verbatim
      * - {_n:str:MCES} for a *shuffled* drop down field, MCE must be verbatim
@@ -1043,7 +1043,7 @@ class qtype_formulas_part {
      */
     public static function scan_for_answer_boxes(string $text): array {
         // Match the text and store the matches.
-        preg_match_all('/\{(_u|_\d+)(:(_[A-Za-z]|[A-Za-z]\w*)(:(MCE|MCS|MCES))?)?((\|[\w .=#]*)*)\}/', $text, $matches);
+        preg_match_all('/\{(_u|_\d+)(:(_[A-Za-z]|[A-Za-z]\w*)(:(MC|MCE|MCS|MCES))?)?((\|[\w .=#]*)*)\}/', $text, $matches);
 
         $boxes = [];
 
@@ -1057,9 +1057,8 @@ class qtype_formulas_part {
             // text is later needed to replace the placeholder by the input element.
             // With $matches[3], we can access the name of the variable containing the options for the radio
             // boxes or the drop down list.
-            // Finally, the array $matches[4] will contain ':MCE', ':MCES' or ':MCS' in case this has been
+            // Finally, the array $matches[4] will contain ':MC', ':MCE', ':MCES' or ':MCS' in case this has been
             // specified. Otherwise, there will be an empty string.
-            // TODO: add option 'size' (for characters) or 'width' (for pixel width).
             $boxes[$match] = [
                 'placeholder' => $matches[0][$i],
                 'options' => $matches[3][$i],

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -1085,14 +1085,20 @@ final class question_test extends \advanced_testcase {
                 '_0' => ['placeholder' => '{_0:MCE}', 'options' => 'MCE'],
             ], '{_0:MCE}'],
             [[
-                '_0' => ['placeholder' => '{_0:MCS}', 'options' => 'MCS', 'dropdown' => false, 'shuffle' => false],
+                '_0' => ['placeholder' => '{_0:MC}', 'options' => 'MC'],
+            ], '{_0:MC}'],
+            [[
+                '_0' => ['placeholder' => '{_0:MCS}', 'options' => 'MCS'],
             ], '{_0:MCS}'],
             [[
-                '_0' => ['placeholder' => '{_0:MCES}', 'options' => 'MCES', 'dropdown' => false, 'shuffle' => false],
+                '_0' => ['placeholder' => '{_0:MCES}', 'options' => 'MCES'],
             ], '{_0:MCES}'],
             [[
-                '_0' => ['placeholder' => '{_0:foo:MCE}', 'options' => 'foo', 'dropdown' => true, 'shuffle' => false],
+                '_0' => ['placeholder' => '{_0:foo:MCE}', 'options' => 'foo', 'dropdown' => true],
             ], '{_0:foo:MCE}'],
+            [[
+                '_0' => ['placeholder' => '{_0:foo:MC}', 'options' => 'foo'],
+            ], '{_0:foo:MC}'],
             [[
                 '_0' => [
                     'placeholder' => '{_0:foo:MCE|align=center|bgcol=red|w=10}',
@@ -1127,6 +1133,15 @@ final class question_test extends \advanced_testcase {
             [[
                 '_0' => ['placeholder' => '{_0:MCS:MCS}', 'options' => 'MCS', 'shuffle' => true],
             ], '{_0:MCS:MCS}'],
+            [[
+                '_0' => ['placeholder' => '{_0:MC:MC}', 'options' => 'MC'],
+            ], '{_0:MC:MC}'],
+            [[
+                '_0' => ['placeholder' => '{_0:MC:MCS}', 'options' => 'MC', 'shuffle' => true],
+            ], '{_0:MC:MCS}'],
+            [[
+                '_0' => ['placeholder' => '{_0:MCS:MC}', 'options' => 'MCS'],
+            ], '{_0:MCS:MC}'],
             [[
                 '_0' => ['placeholder' => '{_0:MCES:MCES}', 'options' => 'MCES', 'dropdown' => true, 'shuffle' => true],
             ], '{_0:MCES:MCES}'],


### PR DESCRIPTION
Fixes #262 

Hello @azmatksa

This PR will add the syntax you have used. You can download it [here](https://github.com/PhilippImhof/moodle-qtype_formulas/archive/refs/heads/allow-mc.zip) and give it a try.

I will merge it soon, but I will not immediately publish a new version just for that.