### PR TITLE
Update PostgreSQL to 15

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:15
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'


### PR DESCRIPTION
Use PostgreSQL 15 instead of 14 in order to run tests on Moodle's current main (future 5.1)