### PR TITLE
Fix problems with rendering and formatting of combined unit field

### DIFF
--- a/question.php
+++ b/question.php
@@ -959,9 +959,18 @@ class qtype_formulas_part {
 
         // Furthermore, there must be either a {_0}{_u} without whitespace in the part's text
         // (meaning the user explicitly wants a combined unit field) or no answer box placeholders
-        // at all, neither for the answer nor for the unit.
-        $combinedrequested = strpos($this->subqtext, '{_0}{_u}') !== false;
-        $noplaceholders = strpos($this->subqtext, '{_0}') === false && strpos($this->subqtext, '{_u}') === false;
+        // at all, neither for the answer nor for the unit. As the placeholders may contain formatting
+        // options, it makes sense to first simplify the part's question text by removing those. Note
+        // that the regex is different from e. g. the one in scan_for_answer_boxes(), because there
+        // MUST NOT be an :options-variable or a :MC/:MCE/:MCES/:MCS part.
+        $simplifiedtext = preg_replace(
+            '/\{(_u|_\d+)((\|[\w =#]*)*)\}/',
+            '{\1}',
+            $this->subqtext,
+        );
+
+        $combinedrequested = strpos($simplifiedtext, '{_0}{_u}') !== false;
+        $noplaceholders = strpos($simplifiedtext, '{_0}') === false && strpos($this->subqtext, '{_u}') === false;
         return $combinedrequested || $noplaceholders;
     }
 

--- a/renderer.php
+++ b/renderer.php
@@ -666,10 +666,16 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
 
         // If part has combined unit answer input.
         if ($part->has_combined_unit_field()) {
+            // For a combined unit field, we try to merge the formatting options from the {_0} and the
+            // {_u} placeholder, giving precedence to the latter.
+            $mergedformat = $boxes['_u']['format'] + $boxes['_0']['format'];
             $combinedfieldhtml = $this->create_input_box(
-                $part, self::COMBINED_FIELD, $qa, $options, $boxes[$placeholder]['format'], $sub->feedbackclass
+                $part, self::COMBINED_FIELD, $qa, $options, $mergedformat, $sub->feedbackclass
             );
-            return str_replace('{_0}{_u}', $combinedfieldhtml, $subqreplaced);
+            // The combined field must be placed where the user has the {_0}{_u} placeholders, possibly with
+            // their formatting options.
+            $boxplaceholders = $boxes['_0']['placeholder'] . $boxes['_u']['placeholder'];
+            return str_replace($boxplaceholders, $combinedfieldhtml, $subqreplaced);
         }
 
         // Iterate over all boxes again, this time creating the appropriate input control and insert it


### PR DESCRIPTION
This PR fixes the problems in #267  and #266. It has two changes:

- Prior to #235, users could specify `{_0}{_u}` (with no space) in order to obtain a combined unit field. As there can now be options, it's possible to have `{_0|width=100px}{_u|bgcol=red}`. Unfortunately, I forgot that and was still searching for just `{_0}{_u}`.
- Also, insertion of the combined field, once it was rendered, occurred at the position of the `{_0}{_u}` placeholders. I forgot to dynamically create the search string, taking into account the actual placeholder with its formatting options.

If the user adds formatting to both the `{_0}` and the `{_u}` part, the plugin will merge the options. In case of conflicts, the options from the `{_u}` field (the latter) will be used.