### PR TITLE
Update CI for Moodle 5.1

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -23,12 +23,14 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.1', '8.2']
-        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'MOODLE_404_STABLE', 'MOODLE_405_STABLE', 'MOODLE_500_STABLE', 'main']
+        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'MOODLE_404_STABLE', 'MOODLE_405_STABLE', 'MOODLE_500_STABLE', 'MOODLE_501_STABLE', 'main']
         database: [mariadb]
         exclude:
           - moodle-branch: 'MOODLE_401_STABLE'
             php: '8.2'
           - moodle-branch: 'MOODLE_500_STABLE'
+            php: '8.1'
+          - moodle-branch: 'MOODLE_501_STABLE'
             php: '8.1'
           - moodle-branch: 'main'
             php: '8.1'
@@ -55,10 +57,16 @@ jobs:
             moodle-branch: 'MOODLE_500_STABLE'
             database: 'mariadb'
           - php: '8.3'
+            moodle-branch: 'MOODLE_501_STABLE'
+            database: 'mariadb'
+          - php: '8.3'
             moodle-branch: 'main'
             database: 'mariadb'
           - php: '8.4'
             moodle-branch: 'MOODLE_500_STABLE'
+            database: 'mariadb'
+          - php: '8.4'
+            moodle-branch: 'MOODLE_501_STABLE'
             database: 'mariadb'
           - php: '8.4'
             moodle-branch: 'main'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,12 +32,14 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.1', '8.2']
-        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'MOODLE_404_STABLE', 'MOODLE_405_STABLE', 'MOODLE_500_STABLE', 'main']
+        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'MOODLE_404_STABLE', 'MOODLE_405_STABLE', 'MOODLE_500_STABLE', 'MOODLE_501_STABLE', 'main']
         database: [pgsql]
         exclude:
           - moodle-branch: 'MOODLE_401_STABLE'
             php: '8.2'
           - moodle-branch: 'MOODLE_500_STABLE'
+            php: '8.1'
+          - moodle-branch: 'MOODLE_501_STABLE'
             php: '8.1'
           - moodle-branch: 'main'
             php: '8.1'
@@ -64,10 +66,16 @@ jobs:
             moodle-branch: 'MOODLE_500_STABLE'
             database: 'pgsql'
           - php: '8.3'
+            moodle-branch: 'MOODLE_501_STABLE'
+            database: 'pgsql'
+          - php: '8.3'
             moodle-branch: 'main'
             database: 'pgsql'
           - php: '8.4'
             moodle-branch: 'MOODLE_500_STABLE'
+            database: 'pgsql'
+          - php: '8.4'
+            moodle-branch: 'MOODLE_501_STABLE'
             database: 'pgsql'
           - php: '8.4'
             moodle-branch: 'main'


### PR DESCRIPTION
Moodle 5.1 is going to be released in just a few days and the repository has just been tagged with the 5.1.0 version, so it's time to update the CI.