### PR TITLE
Improve syntax check and MathJax preview

### DIFF
--- a/classes/local/answer_parser.php
+++ b/classes/local/answer_parser.php
@@ -364,7 +364,7 @@ class answer_parser extends parser {
                 // We do not pop the second argument, because we will later need to put
                 // the "result" of the operation back onto the stack anyway.
                 $second = end($stack);
-                if (!($second instanceof token) || !self::could_be_argument($second)) {
+                if ($second === false || !self::could_be_argument($second)) {
                     return false;
                 }
                 // Check has passed. We do not put the operator on the stack, because it has

--- a/classes/local/latexifier.php
+++ b/classes/local/latexifier.php
@@ -116,6 +116,14 @@ class latexifier {
                 // everything to a dedicated function to build the next expression.
                 if (in_array($op, ['+', '-', '*', '/', '%', '**', '^', '==', '<=', '>=', '!='])) {
                     $first = array_pop($stack);
+                    // The stack should not be empty, but it might be in case of certain syntax errors.
+                    // In that case, we want to avoid dropping out with an error message, because that
+                    // could block the student from continuing a quiz. Instead, we create an empty token
+                    // and will (probably) finish by returning some bad output following the principle
+                    // "garbe in, garbage out".
+                    if ($first === null) {
+                        $first = ['content' => '', 'precedence' => PHP_INT_MAX];
+                    }
                     $new = self::build_binary_part($op, $first, $second);
                 }
                 $stack[] = ['content' => $new, 'precedence' => shunting_yard::get_precedence($op)];

--- a/tests/answer_parser_test.php
+++ b/tests/answer_parser_test.php
@@ -82,6 +82,7 @@ final class answer_parser_test extends \advanced_testcase {
             [qtype_formulas::ANSWER_TYPE_ALGEBRAIC, 'a*b'],
             [false, '1/*8'],
             [false, '1* *8'],
+            [false, 'sin(/)'],
             [false, '(1+2)*ln'],
             [false, '\sin(3)'],
             [false, 'sin(3+)'],

--- a/tests/answer_parser_test.php
+++ b/tests/answer_parser_test.php
@@ -80,6 +80,8 @@ final class answer_parser_test extends \advanced_testcase {
             [qtype_formulas::ANSWER_TYPE_ALGEBRAIC, '3e 10'],
             [qtype_formulas::ANSWER_TYPE_ALGEBRAIC, '3e8e8'],
             [qtype_formulas::ANSWER_TYPE_ALGEBRAIC, 'a*b'],
+            [false, '1/*8'],
+            [false, '1* *8'],
             [false, '(1+2)*ln'],
             [false, '\sin(3)'],
             [false, 'sin(3+)'],
@@ -150,6 +152,8 @@ final class answer_parser_test extends \advanced_testcase {
             [qtype_formulas::ANSWER_TYPE_ALGEBRAIC, '3e8e8'],
             // Note: the following is syntactically valid and is read as 3e8*e8e8; it can be evaluated if e8e8 is a valid variable.
             [qtype_formulas::ANSWER_TYPE_ALGEBRAIC, '3e8e8e8'],
+            [false, 'a/*b'],
+            [false, 'a* *b'],
             [false, 'a-'],
             [false, '*a'],
             [false, 'a+^c+f'],

--- a/tests/latexifier_test.php
+++ b/tests/latexifier_test.php
@@ -99,6 +99,8 @@ final class latexifier_test extends \advanced_testcase {
             ['\lg\left(12\right)', 'log10(12)'],
             ['\operatorname{arctan2}\left(1, 3\right)', 'atan2(1, 3)'],
             ['\operatorname{pick}\left(12\right)', 'pick(12)'],
+            ['\frac{}{1}\cdot 2', '1/*2'],
+            ['\cdot 1\cdot 2', '1* *2'],
         ];
     }
 


### PR DESCRIPTION
Fixes #289 

This PR makes the following changes:

- Add syntax checking for answer type "Numeric". This is necessary, because a valid "Numeric" answer is also a valid "Numerical formula" answer. If there is a syntax error like `1/*8`, this would pass checks for "Numeric" answers prior to this PR and thus also pass "Numerical formula".

- The LaTeXifier should not normally be called with invalid input. But in the case shown above, as the syntax check was not as rigorous as it should have been, the invalid input would be passed to the LaTeXifier and then led to an error during rendering of the preview, because the expression does not make sense mathematically. The PR adds some fallback for cases like this. Instead of failing (and displaying an error message that could potentially block students during a quiz), the renderer will return an invalid formula.