### PR TITLE
Allow spaces around variable name in MC input

### DIFF
--- a/classes/local/formulas_part.php
+++ b/classes/local/formulas_part.php
@@ -252,7 +252,11 @@ class formulas_part {
      */
     public static function scan_for_answer_boxes(string $text): array {
         // Match the text and store the matches.
-        preg_match_all('/\{(_u|_\d+)(:\s*(_[A-Za-z]|[A-Za-z]\w*)\s*(:(MC|MCE|MCS|MCES))?)?((\|[\w .=#]*)*)\}/u', $text, $matches);
+        preg_match_all(
+            '/\{(_u|_\d+)(:\s*(_[A-Za-z]|[A-Za-z][A-Za-z_]*)\s*(:(MC|MCE|MCS|MCES))?)?((\|[A-Za-z0-9_ .=#]*)*)\}/u',
+            $text,
+            $matches
+        );
 
         $boxes = [];
 

--- a/classes/local/formulas_part.php
+++ b/classes/local/formulas_part.php
@@ -252,7 +252,7 @@ class formulas_part {
      */
     public static function scan_for_answer_boxes(string $text): array {
         // Match the text and store the matches.
-        preg_match_all('/\{(_u|_\d+)(:(_[A-Za-z]|[A-Za-z]\w*)(:(MC|MCE|MCS|MCES))?)?((\|[\w .=#]*)*)\}/', $text, $matches);
+        preg_match_all('/\{(_u|_\d+)(:\s*(_[A-Za-z]|[A-Za-z]\w*)\s*(:(MC|MCE|MCS|MCES))?)?((\|[\w .=#]*)*)\}/', $text, $matches);
 
         $boxes = [];
 

--- a/classes/local/formulas_part.php
+++ b/classes/local/formulas_part.php
@@ -253,7 +253,7 @@ class formulas_part {
     public static function scan_for_answer_boxes(string $text): array {
         // Match the text and store the matches.
         preg_match_all(
-            '/\{(_u|_\d+)(:\s*([A-Za-z][A-Za-z_]*)\s*(:(MC|MCE|MCS|MCES))?)?((\|[A-Za-z0-9_ .=#]*)*)\}/u',
+            '/\{(_u|_\d+)(:\s*([A-Za-z][A-Za-z_0-9]*)\s*(:(MC|MCE|MCS|MCES))?)?((\|[A-Za-z0-9_ .=#]*)*)\}/u',
             $text,
             $matches
         );

--- a/classes/local/formulas_part.php
+++ b/classes/local/formulas_part.php
@@ -253,7 +253,7 @@ class formulas_part {
     public static function scan_for_answer_boxes(string $text): array {
         // Match the text and store the matches.
         preg_match_all(
-            '/\{(_u|_\d+)(:\s*(_[A-Za-z]|[A-Za-z][A-Za-z_]*)\s*(:(MC|MCE|MCS|MCES))?)?((\|[A-Za-z0-9_ .=#]*)*)\}/u',
+            '/\{(_u|_\d+)(:\s*([A-Za-z][A-Za-z_]*)\s*(:(MC|MCE|MCS|MCES))?)?((\|[A-Za-z0-9_ .=#]*)*)\}/u',
             $text,
             $matches
         );

--- a/classes/local/formulas_part.php
+++ b/classes/local/formulas_part.php
@@ -252,7 +252,7 @@ class formulas_part {
      */
     public static function scan_for_answer_boxes(string $text): array {
         // Match the text and store the matches.
-        preg_match_all('/\{(_u|_\d+)(:\s*(_[A-Za-z]|[A-Za-z]\w*)\s*(:(MC|MCE|MCS|MCES))?)?((\|[\w .=#]*)*)\}/', $text, $matches);
+        preg_match_all('/\{(_u|_\d+)(:\s*(_[A-Za-z]|[A-Za-z]\w*)\s*(:(MC|MCE|MCS|MCES))?)?((\|[\w .=#]*)*)\}/u', $text, $matches);
 
         $boxes = [];
 

--- a/question.php
+++ b/question.php
@@ -231,7 +231,7 @@ class qtype_formulas_question extends question_graded_automatically_with_countba
 
         // For the question summary, it seems useful to simplify the answer box placeholders.
         $summary = preg_replace(
-            '/\{(_u|_\d+)(:\s*(_[A-Za-z]|[A-Za-z]\w*)\s*(:(MC|MCE|MCES|MCS))?)?((\|[\w =#]*)*)\}/u',
+            '/\{(_u|_\d+)(:\s*(_[A-Za-z]|[A-Za-z][A-Za-z_]*)\s*(:(MC|MCE|MCS|MCES))?)?((\|[A-Za-z0-9_ .=#]*)*)\}/u',
             '{\1}',
             $summary,
         );

--- a/question.php
+++ b/question.php
@@ -231,7 +231,7 @@ class qtype_formulas_question extends question_graded_automatically_with_countba
 
         // For the question summary, it seems useful to simplify the answer box placeholders.
         $summary = preg_replace(
-            '/\{(_u|_\d+)(:(_[A-Za-z]|[A-Za-z]\w*)(:(MC|MCE|MCES|MCS))?)?((\|[\w =#]*)*)\}/',
+            '/\{(_u|_\d+)(:\s*(_[A-Za-z]|[A-Za-z]\w*)\s*(:(MC|MCE|MCES|MCS))?)?((\|[\w =#]*)*)\}/',
             '{\1}',
             $summary,
         );

--- a/question.php
+++ b/question.php
@@ -231,7 +231,7 @@ class qtype_formulas_question extends question_graded_automatically_with_countba
 
         // For the question summary, it seems useful to simplify the answer box placeholders.
         $summary = preg_replace(
-            '/\{(_u|_\d+)(:\s*([A-Za-z][A-Za-z_]*)\s*(:(MC|MCE|MCS|MCES))?)?((\|[A-Za-z0-9_ .=#]*)*)\}/u',
+            '/\{(_u|_\d+)(:\s*([A-Za-z][A-Za-z_0-9]*)\s*(:(MC|MCE|MCS|MCES))?)?((\|[A-Za-z0-9_ .=#]*)*)\}/u',
             '{\1}',
             $summary,
         );

--- a/question.php
+++ b/question.php
@@ -231,7 +231,7 @@ class qtype_formulas_question extends question_graded_automatically_with_countba
 
         // For the question summary, it seems useful to simplify the answer box placeholders.
         $summary = preg_replace(
-            '/\{(_u|_\d+)(:\s*(_[A-Za-z]|[A-Za-z][A-Za-z_]*)\s*(:(MC|MCE|MCS|MCES))?)?((\|[A-Za-z0-9_ .=#]*)*)\}/u',
+            '/\{(_u|_\d+)(:\s*([A-Za-z][A-Za-z_]*)\s*(:(MC|MCE|MCS|MCES))?)?((\|[A-Za-z0-9_ .=#]*)*)\}/u',
             '{\1}',
             $summary,
         );

--- a/question.php
+++ b/question.php
@@ -231,7 +231,7 @@ class qtype_formulas_question extends question_graded_automatically_with_countba
 
         // For the question summary, it seems useful to simplify the answer box placeholders.
         $summary = preg_replace(
-            '/\{(_u|_\d+)(:\s*(_[A-Za-z]|[A-Za-z]\w*)\s*(:(MC|MCE|MCES|MCS))?)?((\|[\w =#]*)*)\}/',
+            '/\{(_u|_\d+)(:\s*(_[A-Za-z]|[A-Za-z]\w*)\s*(:(MC|MCE|MCES|MCS))?)?((\|[\w =#]*)*)\}/u',
             '{\1}',
             $summary,
         );

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -1087,6 +1087,9 @@ final class question_test extends \advanced_testcase {
                 '_0' => ['placeholder' => '{_0:  foo   }', 'options' => 'foo'],
             ], '{_0:  foo   }'],
             [[
+                '_0' => ['placeholder' => '{_0: foo }', 'options' => 'foo'],
+            ], '{_0: foo }'],
+            [[
                 '_0' => ['placeholder' => '{_0:foo|align=center|bgcol=red|w=10}', 'options' => 'foo', 'format' => $formatarray],
             ], '{_0:foo|align=center|bgcol=red|w=10}'],
             [[

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -1053,6 +1053,8 @@ final class question_test extends \advanced_testcase {
             [[], '{_0::}'],
             [[], '{_0::MCE}'],
             [[], '{_0:foo:}'],
+            // The capital E is not an ASCII character, so it should not match.
+            [[], '{_0:TΕ}'],
             [[], '{ _0:foo}'],
             [[], '{ _u}'],
             [[], '{_ u}'],

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -1089,6 +1089,9 @@ final class question_test extends \advanced_testcase {
                 '_0' => ['placeholder' => '{_0:foo1}', 'options' => 'foo1'],
             ], '{_0:foo1}'],
             [[
+                '_0' => ['placeholder' => '{_0:fO_o1}', 'options' => 'fO_o1'],
+            ], '{_0:fO_o1}'],
+            [[
                 '_0' => ['placeholder' => '{_0:mychoices}', 'options' => 'mychoices'],
             ], '{_0:mychoices}'],
             [[

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -1086,6 +1086,12 @@ final class question_test extends \advanced_testcase {
                 '_0' => ['placeholder' => '{_0:foo}', 'options' => 'foo'],
             ], '{_0:foo}'],
             [[
+                '_0' => ['placeholder' => '{_0:foo1}', 'options' => 'foo1'],
+            ], '{_0:foo1}'],
+            [[
+                '_0' => ['placeholder' => '{_0:mychoices}', 'options' => 'mychoices'],
+            ], '{_0:mychoices}'],
+            [[
                 '_0' => ['placeholder' => '{_0:  foo   }', 'options' => 'foo'],
             ], '{_0:  foo   }'],
             [[

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -1053,12 +1053,12 @@ final class question_test extends \advanced_testcase {
             [[], '{_0::}'],
             [[], '{_0::MCE}'],
             [[], '{_0:foo:}'],
-            [[], '{_0:foo }'],
             [[], '{ _0:foo}'],
             [[], '{ _u}'],
             [[], '{_ u}'],
             [[], '{_u }'],
             [[], '{_a}'],
+            [['_0' => ['placeholder' => '{_0:foo }', 'options' => 'foo']], '{_0:foo }'],
             [[
                 '_0' => ['placeholder' => '{_0}'],
             ], '{_0}'],
@@ -1084,6 +1084,9 @@ final class question_test extends \advanced_testcase {
                 '_0' => ['placeholder' => '{_0:foo}', 'options' => 'foo'],
             ], '{_0:foo}'],
             [[
+                '_0' => ['placeholder' => '{_0:  foo   }', 'options' => 'foo'],
+            ], '{_0:  foo   }'],
+            [[
                 '_0' => ['placeholder' => '{_0:foo|align=center|bgcol=red|w=10}', 'options' => 'foo', 'format' => $formatarray],
             ], '{_0:foo|align=center|bgcol=red|w=10}'],
             [[
@@ -1104,6 +1107,9 @@ final class question_test extends \advanced_testcase {
             [[
                 '_0' => ['placeholder' => '{_0:foo:MC}', 'options' => 'foo'],
             ], '{_0:foo:MC}'],
+            [[
+                '_0' => ['placeholder' => '{_0:   foo   :MC}', 'options' => 'foo'],
+            ], '{_0:   foo   :MC}'],
             [[
                 '_0' => [
                     'placeholder' => '{_0:foo:MCE|align=center|bgcol=red|w=10}',


### PR DESCRIPTION
Fixes #288 

This PR will make sure that when defining multiple-choice answer boxes the user can have spaces around the variable name. Although this has never been a documented feature, legacy versions did indeed accept `{_0:  foo  }` or `{_0:  foo  :MCE}`.

As some users might have questions with such rogue spaces, it makes sense to allow that.