### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: plugin
 

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Automated acceptance tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     services:
       mariadb:
@@ -22,56 +22,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2']
-        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'MOODLE_404_STABLE', 'MOODLE_405_STABLE', 'MOODLE_500_STABLE', 'MOODLE_501_STABLE', 'main']
+        php: ['8.2', '8.3', '8.4']
+        moodle-branch: ['MOODLE_405_STABLE', 'MOODLE_500_STABLE', 'MOODLE_501_STABLE', 'main']
         database: [mariadb]
         exclude:
-          - moodle-branch: 'MOODLE_401_STABLE'
-            php: '8.2'
-          - moodle-branch: 'MOODLE_500_STABLE'
-            php: '8.1'
-          - moodle-branch: 'MOODLE_501_STABLE'
-            php: '8.1'
+          - moodle-branch: 'MOODLE_405_STABLE'
+            php: '8.4'
           - moodle-branch: 'main'
             php: '8.2'
-          - moodle-branch: 'main'
-            php: '8.1'
         include:
-          - php: '7.4'
-            moodle-branch: 'MOODLE_401_STABLE'
-            database: 'mariadb'
-          - php: '8.0'
-            moodle-branch: 'MOODLE_401_STABLE'
-            database: 'mariadb'
-          - php: '8.0'
-            moodle-branch: 'MOODLE_402_STABLE'
-            database: 'mariadb'
-          - php: '8.0'
-            moodle-branch: 'MOODLE_403_STABLE'
-            database: 'mariadb'
-          - php: '8.3'
-            moodle-branch: 'MOODLE_404_STABLE'
-            database: 'mariadb'
-          - php: '8.3'
+          - php: '8.1'
             moodle-branch: 'MOODLE_405_STABLE'
-            database: 'mariadb'
-          - php: '8.3'
-            moodle-branch: 'MOODLE_500_STABLE'
-            database: 'mariadb'
-          - php: '8.3'
-            moodle-branch: 'MOODLE_501_STABLE'
-            database: 'mariadb'
-          - php: '8.3'
-            moodle-branch: 'main'
-            database: 'mariadb'
-          - php: '8.4'
-            moodle-branch: 'MOODLE_500_STABLE'
-            database: 'mariadb'
-          - php: '8.4'
-            moodle-branch: 'MOODLE_501_STABLE'
-            database: 'mariadb'
-          - php: '8.4'
-            moodle-branch: 'main'
             database: 'mariadb'
 
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: plugin
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Automated code checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     services:
       mariadb:
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3', '8.4']
+        php: ['8.2', '8.3', '8.4']
 
     steps:
       - name: Check out repository code
@@ -52,7 +52,7 @@ jobs:
           moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
         env:
           DB: mariadb
-          MOODLE_BRANCH: ${{ matrix.php == '8.1' && 'MOODLE_405_STABLE' || 'MOODLE_501_STABLE'}}
+          MOODLE_BRANCH: MOODLE_501_STABLE
 
       - name: PHP Lint
         if: ${{ always() }}

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   release-at-moodle-org:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       PLUGIN: qtype_formulas
       CURL: curl -s

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,82 +5,32 @@ on: [push, pull_request]
 jobs:
   test:
     name: Automated unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres:15
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
-      mariadb:
-        image: mariadb:10
-        env:
-          MYSQL_USER: 'root'
-          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
-          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
-          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
-
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
 
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2']
-        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'MOODLE_404_STABLE', 'MOODLE_405_STABLE', 'MOODLE_500_STABLE', 'MOODLE_501_STABLE', 'main']
+        php: ['8.2', '8.3', '8.4']
+        moodle-branch: ['MOODLE_405_STABLE', 'MOODLE_500_STABLE', 'MOODLE_501_STABLE', 'main']
         database: [pgsql]
         exclude:
-          - moodle-branch: 'MOODLE_401_STABLE'
-            php: '8.2'
-          - moodle-branch: 'MOODLE_500_STABLE'
-            php: '8.1'
-          - moodle-branch: 'MOODLE_501_STABLE'
-            php: '8.1'
+          - moodle-branch: 'MOODLE_405_STABLE'
+            php: '8.4'
           - moodle-branch: 'main'
             php: '8.2'
-          - moodle-branch: 'main'
-            php: '8.1'
         include:
-          - php: '7.4'
-            moodle-branch: 'MOODLE_401_STABLE'
-            database: 'pgsql'
-          - php: '8.0'
-            moodle-branch: 'MOODLE_401_STABLE'
-            database: 'pgsql'
-          - php: '8.0'
-            moodle-branch: 'MOODLE_402_STABLE'
-            database: 'pgsql'
-          - php: '8.0'
-            moodle-branch: 'MOODLE_403_STABLE'
-            database: 'pgsql'
-          - php: '8.3'
-            moodle-branch: 'MOODLE_404_STABLE'
-            database: 'pgsql'
-          - php: '8.3'
+          - php: '8.1'
             moodle-branch: 'MOODLE_405_STABLE'
-            database: 'pgsql'
-          - php: '8.3'
-            moodle-branch: 'MOODLE_500_STABLE'
-            database: 'pgsql'
-          - php: '8.3'
-            moodle-branch: 'MOODLE_501_STABLE'
-            database: 'pgsql'
-          - php: '8.3'
-            moodle-branch: 'main'
-            database: 'pgsql'
-          - php: '8.4'
-            moodle-branch: 'MOODLE_500_STABLE'
-            database: 'pgsql'
-          - php: '8.4'
-            moodle-branch: 'MOODLE_501_STABLE'
-            database: 'pgsql'
-          - php: '8.4'
-            moodle-branch: 'main'
             database: 'pgsql'
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: plugin
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:16
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'

--- a/README.md
+++ b/README.md
@@ -17,11 +17,7 @@ still available at the [original author's website](https://code.google.com/p/moo
 at the date of this writing. It was then upgraded to the new question engine introduced in Moodle 2.1 by
 Jean-Michel Védrine.
 
-This version is compatible with Moodle 4.1 and newer. It has been tested with:
-- Moodle 4.1 using PHP 7.4, PHP 8.0 and PHP 8.1
-- Moodle 4.2 using PHP 8.0, PHP 8.1 and PHP 8.2
-- Moodle 4.3 using PHP 8.0, PHP 8.1 and PHP 8.2
-- Moodle 4.4 using PHP 8.1, PHP 8.2 and PHP 8.3
+This version is compatible with Moodle 4.5 and newer. It has been tested with:
 - Moodle 4.5 using PHP 8.1, PHP 8.2 and PHP 8.3
 - Moodle 5.0 using PHP 8.2, PHP 8.3 and PHP 8.4
 - Moodle 5.1 using PHP 8.2, PHP 8.3 and PHP 8.4


### PR DESCRIPTION
Moodle versions 4.1, 4.2, 4.3 and 4.4 are out of support. There is no need to maintain compatibility with those. Dropping tests for them also allows to remove compatibility code.

Moodle 4.5 (LTS) is out of support, but still gets security support, so we keep it in.

PHP versions prior to 8.1 are no longer needed, as Moodle 4.5 requires at least PHP 8.1.

Also, we update the runners to use Ubuntu 24.04 instead of 22.04.