### PR TITLE
CI: temporarily pin Chrome to 145

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -67,3 +67,5 @@ jobs:
 
       - name: Behat features
         run: moodle-plugin-ci behat --auto-rerun 1 --profile chrome
+        env:
+          MOODLE_BEHAT_SELENIUM_IMAGE: selenium/standalone-chrome:145.0-20260222


### PR DESCRIPTION
Due to changes in Chrome, Behat tests for the Moodle App may fail until the App is updated.

We will temporarily use Chrome v.145 in Behat testing to avoid the problem.