### PR TITLE
sr-only deprecated

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -283,12 +283,12 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
         $output = html_writer::start_tag('fieldset', ['class' => 'multichoice_answer']);
 
         // Inside the fieldset, we put the accessibility label, following the example of core's multichoice
-        // question type, i. e. the label is inside a <span> with class 'sr-only', wrapped in a <legend>.
+        // question type, i. e. the label is inside a <span> with class 'visually-hidden', wrapped in a <legend>.
         // TODO: we should use visually-hidden after dropping Moodle 4.5.
-        $output .= html_writer::start_tag('legend', ['class' => 'sr-only']);
+        $output .= html_writer::start_tag('legend', ['class' => 'visually-hidden']);
         $output .= html_writer::span(
             $this->generate_accessibility_label_text($answerindex, $part->numbox, $part->partindex, $question->numparts),
-            'sr-only'
+            'visually-hidden'
         );
         $output .= html_writer::end_tag('legend');
 
@@ -422,7 +422,7 @@ class qtype_formulas_renderer extends qtype_with_combined_feedback_renderer {
     protected function create_label_for_input(string $text, string $inputid, array $additionalattributes = []): array {
         $labelid = 'lbl_' . str_replace(':', '__', $inputid);
         $attributes = [
-            'class' => 'subq sr-only',
+            'class' => 'subq visually-hidden',
             'for' => $inputid,
             'id' => $labelid,
         ];

--- a/tests/renderer_test.php
+++ b/tests/renderer_test.php
@@ -727,7 +727,7 @@ final class renderer_test extends walkthrough_test_base {
             new \question_contains_tag_with_attribute('select', 'name', $this->quba->get_field_prefix($this->slot) . '0_0'),
             $this->get_does_not_contain_specific_feedback_expectation(),
             new \question_contains_tag_with_contents('label', 'Answer'),
-            new \question_contains_tag_with_attribute('label', 'class', 'subq sr-only'),
+            new \question_contains_tag_with_attribute('label', 'class', 'subq visually-hidden'),
         );
         $this->check_output_contains_selectoptions(
             $this->get_contains_select_expectation('0_0', ['Dog', 'Cat', 'Bird', 'Fish'], 0)
@@ -894,8 +894,8 @@ final class renderer_test extends walkthrough_test_base {
         $q = $this->get_test_formulas_question('testmc');
         $this->start_attempt_at_question($q, 'immediatefeedback', 1);
         $this->check_current_output(
-            new \question_contains_tag_with_attribute('legend', 'class', 'sr-only'),
-            new \question_contains_tag_with_attribute('span', 'class', 'sr-only'),
+            new \question_contains_tag_with_attribute('legend', 'class', 'visually-hidden'),
+            new \question_contains_tag_with_attribute('span', 'class', 'visually-hidden'),
             new \question_contains_tag_with_contents('span', 'Answer'),
         );
 
@@ -905,7 +905,7 @@ final class renderer_test extends walkthrough_test_base {
         $q->parts[0]->answer = '[1, 1]';
         $this->start_attempt_at_question($q, 'immediatefeedback', 1);
         $this->check_current_output(
-            new \question_contains_tag_with_attribute('legend', 'class', 'sr-only'),
+            new \question_contains_tag_with_attribute('legend', 'class', 'visually-hidden'),
             new \question_contains_tag_with_contents('span', 'Answer field 1'),
             new \question_contains_tag_with_contents('label', 'Answer field 2'),
         );
@@ -919,7 +919,7 @@ final class renderer_test extends walkthrough_test_base {
 
         $this->start_attempt_at_question($q, 'immediatefeedback', 1);
         $this->check_current_output(
-            new \question_contains_tag_with_attribute('legend', 'class', 'sr-only'),
+            new \question_contains_tag_with_attribute('legend', 'class', 'visually-hidden'),
             new \question_contains_tag_with_contents('span', 'Answer field 1 for part 1'),
             new \question_contains_tag_with_contents('label', 'Answer field 2 for part 1'),
             new \question_contains_tag_with_contents('span', 'Answer field 1 for part 2'),


### PR DESCRIPTION
In Bootstrap 5 sr-only() and sr-only-focusable() mixins are renamed to visually-hidden() and visually-hidden-focusable().
See https://moodledev.io/docs/5.3/guides/bs5migration